### PR TITLE
Fix erroneous pressure readings in bme280.c

### DIFF
--- a/components/i2c_devices/sensor/bme280/bme280.c
+++ b/components/i2c_devices/sensor/bme280/bme280.c
@@ -440,7 +440,7 @@ float iot_bme280_read_pressure(bme280_handle_t dev)
         return ESP_FAIL;
     }
 
-    if (iot_bme280_read(dev, BME280_REGISTER_TEMPDATA, 3, data) == ESP_FAIL) {
+    if (iot_bme280_read(dev, BME280_REGISTER_PRESSUREDATA, 3, data) == ESP_FAIL) {
         return ESP_FAIL;
     }
 
@@ -469,7 +469,8 @@ float iot_bme280_read_pressure(bme280_handle_t dev)
     var2 = (((int64_t) device->data_t.dig_p8) * p) >> 19;
 
     p = ((p + var1 + var2) >> 8) + (((int64_t) device->data_t.dig_p7) << 4);
-    return ((float) p / 256.0);
+    p = p >> 8; // /256
+    return ((float) p / 100);
 }
 
 float iot_bme280_read_humidity(bme280_handle_t dev)


### PR DESCRIPTION
Fixes #10 
- Read the correct register BME280_REGISTER_PRESSUREDATA instead of BME280_REGISTER_TEMPDATA
- For consistency, divide result by 100 to get the pressure in hPa. This point is open to discussion, but altitude() and calculates_pressure() require the pressure in hPa.