### PR TITLE
Update of touch sensor pin for section 3.2.2

### DIFF
--- a/documents/touch_pad_solution/touch_sensor_design_en.md
+++ b/documents/touch_pad_solution/touch_sensor_design_en.md
@@ -419,7 +419,7 @@ The adjacent pins should not be assigned high-frequency signals such as SPI，I2
 
 <img src="../_static/touch_pad/module_copper_layer.png" width = "300" alt="module_copper_layer" align=center />
 
-> Note: T0 (GPIO0) can function both as a touch sensor pin and a download pin. The download function should not affect the touch function. Use a jumper cap or resistor to select download function for debugging, or touch function for manufacturing.
+> Note: T1 (GPIO0) can function both as a touch sensor pin and a download pin. The download function should not affect the touch function. Use a jumper cap or resistor to select download function for debugging, or touch function for manufacturing.
 
 #### 3.2.3. Power Domains
 


### PR DESCRIPTION
Previously it was wrongly referenced to T0 instead of T1 for GPIO0.
The chinese version has the correct reference.