### PR TITLE
Reinstate API macros required by existing SPI and I2C LCD drivers

### DIFF
--- a/components/display/screen/screen_utility/interface_drv_def.h
+++ b/components/display/screen/screen_utility/interface_drv_def.h
@@ -20,17 +20,13 @@ extern "C" {
 #endif
 
 /**< Define the function of interface instance */
+#define LCD_WRITE_CMD(cmd)      g_lcd_handle.interface_drv->write_cmd(g_lcd_handle.interface_drv, (cmd))
 #define LCD_WRITE_COMMAND(data, length) g_lcd_handle.interface_drv->write_command(g_lcd_handle.interface_drv, (data), (length))
 #define LCD_WRITE(data, length) g_lcd_handle.interface_drv->write(g_lcd_handle.interface_drv, (data), (length))
 #define LCD_READ(data, length)  g_lcd_handle.interface_drv->read(g_lcd_handle.interface_drv, (data), (length))
 #define LCD_IFACE_ACQUIRE()     g_lcd_handle.interface_drv->bus_acquire(g_lcd_handle.interface_drv)
 #define LCD_IFACE_RELEASE()     g_lcd_handle.interface_drv->bus_release(g_lcd_handle.interface_drv)
 
-
-static inline esp_err_t LCD_WRITE_CMD(uint8_t cmd)
-{
-    return LCD_WRITE_COMMAND((uint8_t*)&cmd, 1);
-}
 
 static inline esp_err_t LCD_WRITE_CMD_16B(uint16_t cmd)
 {


### PR DESCRIPTION
SPI (and presumably I2C) LCD drivers were broken by commit https://github.com/espressif/esp-iot-solution/commit/0caa2de5567a17507bc9f542d0bf212637cf3efe

This PR fixes the broken SPI and I2C drivers (tested only against the ILI9341 SPI driver). I think it is a non-breaking change to the I2S drivers, they seem to have functions implemented for both write_cmd and write_command functions.

The commit changed the components/display/screen/screen_utility/interface_drv_def.h API without updating the existing drivers using the API. Specifically, the SPI drivers call the LCD_WRITE_CMD() macro; This previously remapped to the interface_drv->write_cmd function which existed.
The change introduced a new macro, LCD_WRITE_COMMAND() which is a variable length version of LCD_WRITE_CMD(), which remapped to the new function interface_drv->write_command. The LCD_WRITE_CMD() macro was changed to reference the LCD_WRITE_COMMAND() macro, which for the SPI and I2C drivers calls a non-existent function. The write_cmd function was left dangling, never used.

This reinstates the LCD_WRITE_CMD() macro referring to the write_cmd function. The LCD_WRITE_COMMAND() macro and write_command function remains dangling for the SPI and I2C drivers - but it's a new function they don't use.

The choice to use a generic length write_command and write_data function when most (all?) instructions are fixed length may have a performance impact - I have no strong opinion on this but am surprised by it.

In this PR I have left the write_data function dangling, the breaking commit removed all uses of it in favour of the generic length LCD_WRITE (write) macro/function. I have no opinion on whether the previous LCD_WRITE_DATA macro should be reinstated, or whether the write_data function should be removed from scr_interface_driver.h

Properly, I figure all the LCD drivers should either get updated to instate the generic length write_command, and restore use of the write_data function, or the now dangling write_data function https://github.com/dvosully/esp-iot-solution/blob/611cca278ad25a321134cf502bcdb42c2ef2f26f/components/display/screen/interface_driver/scr_interface_driver.h#L67 should be removed entirely. Doing this would at least have thrown a compilation error on the breaking change.

I'll leave it to wiser and more experienced heads than mine to decide.