### PR TITLE
ci: Upload GH action

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -1,0 +1,20 @@
+name: Push components to Espressif Component Service
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          submodules: 'recursive'
+      - name: Upload components to component service
+        uses: espressif/github-actions/upload_components@master
+        with:
+          directories: "components/button"
+          namespace: "espressif"
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
This PR is an example of how to upload components to ESP component registry.

Currently only the button component from #138 PR is processed.

In order to upload to Espressif's registry, an API token must be added to Github secrets (see [.github/workflows/esp_upload_component.yml line 19](https://github.com/espressif/esp-iot-solution/compare/master...tore-espressif:feature/upload_cmps_gh_action?expand=1#diff-c82c40bdd26660633cfb0a9b0c72994b2c94ffe35b4c54206eca877c9a44ccf0R20), I can send it to you in private message.