### PR TITLE
button: fix build on IDF version >= 5

### DIFF
--- a/components/button/CMakeLists.txt
+++ b/components/button/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(SRCS "button_adc.c" "button_gpio.c" "iot_button.c"
                         INCLUDE_DIRS include
-                        PRIV_REQUIRES esp_adc_cal)
+                        REQUIRES driver
+                        PRIV_REQUIRES esp_adc_cal esp_timer)

--- a/components/button/idf_component.yml
+++ b/components/button/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: GPIO and ADC button driver
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/button
 dependencies:


### PR DESCRIPTION
Since IDF version 5, dependency on `driver` and `esp_timer` must be specified in CMake.

This PR fixes the problem for button component.