### PR TITLE
button: fix ADC changes for IDF version >= 5.

### DIFF
--- a/components/button/CMakeLists.txt
+++ b/components/button/CMakeLists.txt
@@ -1,4 +1,12 @@
+set(PRIVREQ esp_timer)
+
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
+    list(APPEND PRIVREQ esp_adc)
+else() 
+    list(APPEND PRIVREQ esp_adc_cal)
+endif()
+
 idf_component_register(SRCS "button_adc.c" "button_gpio.c" "iot_button.c"
                         INCLUDE_DIRS include
                         REQUIRES driver
-                        PRIV_REQUIRES esp_adc_cal esp_timer)
+                        PRIV_REQUIRES ${PRIVREQ})

--- a/components/button/idf_component.yml
+++ b/components/button/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.0"
+version: "2.2.0"
 description: GPIO and ADC button driver
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/button
 dependencies:


### PR DESCRIPTION
There is breaking change in ADC component `esp_adc_cal` changed to `esp_adc` in IDF v5.0 

This PR fixes the problem for button component.

Tested with latest IDF master.