### PR TITLE
iot_button_count_cb added

### DIFF
--- a/components/button/include/iot_button.h
+++ b/components/button/include/iot_button.h
@@ -107,6 +107,17 @@ esp_err_t iot_button_register_cb(button_handle_t btn_handle, button_event_t even
  */
 esp_err_t iot_button_unregister_cb(button_handle_t btn_handle, button_event_t event);
 
+
+
+/**
+ * @brief how many Callbacks are still registered.
+ *
+ * @param btn_handle A button handle to unregister
+ *
+ * @return 0 if no callbacks registered, or 1 .. (BUTTON_EVENT_MAX-1) for the number of Registered Buttons.
+ */
+size_t iot_button_count_cb(button_handle_t btn_handle);
+
 /**
  * @brief Get button event
  *

--- a/components/button/iot_button.c
+++ b/components/button/iot_button.c
@@ -292,6 +292,19 @@ esp_err_t iot_button_unregister_cb(button_handle_t btn_handle, button_event_t ev
     return ESP_OK;
 }
 
+size_t iot_button_count_cb(button_handle_t btn_handle)
+{
+    BTN_CHECK(NULL != btn_handle, "Pointer of handle is invalid", ESP_ERR_INVALID_ARG);
+    button_dev_t *btn = (button_dev_t *) btn_handle;
+	size_t ret = 0;
+    for (size_t i = 0; i < BUTTON_EVENT_MAX; i++) {
+    	if(btn->cb[i]) ret++;
+    }
+    return ret;
+}
+
+
+
 button_event_t iot_button_get_event(button_handle_t btn_handle)
 {
     BTN_CHECK(NULL != btn_handle, "Pointer of handle is invalid", BUTTON_NONE_PRESS);


### PR DESCRIPTION
iot_button_count_cb added

make possible to count the Number of Callbacks. 
this is especially important when you call iot_button_unregister_cb, and are not sure if other callers are still on this Button. 

so you can: 
```
  iot_button_unregister_cb(g_btn, EVENT);
  if (0 == iot_button_count_cb(g_btn)) {
    iot_button_delete(g_btn);
  }
```