### PR TITLE
Add GPIO number check when creating a GPIO button

### DIFF
--- a/components/button/button_gpio.c
+++ b/components/button/button_gpio.c
@@ -28,6 +28,7 @@ static const char *TAG = "gpio button";
 esp_err_t button_gpio_init(const button_gpio_config_t *config)
 {
     GPIO_BTN_CHECK(NULL != config, "Pointer of config is invalid", ESP_ERR_INVALID_ARG);
+    GPIO_BTN_CHECK(GPIO_IS_VALID_GPIO(config->gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
 
     gpio_config_t gpio_conf;
     gpio_conf.intr_type = GPIO_INTR_DISABLE;


### PR DESCRIPTION
> 创建GPIO Button时，没有检查config的GPIO Num参数的正确性

gpio_num is not checked when creating a GPIO button