### PR TITLE
button: Add serial interval

### DIFF
--- a/components/button/Kconfig
+++ b/components/button/Kconfig
@@ -22,6 +22,13 @@ menu "IoT Button"
         range 500 5000
         default 1500
 
+    config BUTTON_SERIAL_TIME_MS
+        int "BUTTON SERIAL TIME (MS)"
+        range 2 1000
+        default 20
+        help
+            "Serial trigger interval"
+
     config ADC_BUTTON_MAX_CHANNEL
         int "ADC BUTTON MAX CHANNEL"
         range 1 5

--- a/components/button/iot_button.c
+++ b/components/button/iot_button.c
@@ -56,6 +56,7 @@ static bool g_is_timer_running = false;
 #define DEBOUNCE_TICKS    CONFIG_BUTTON_DEBOUNCE_TICKS //MAX 8
 #define SHORT_TICKS       (CONFIG_BUTTON_SHORT_PRESS_TIME_MS /TICKS_INTERVAL)
 #define LONG_TICKS        (CONFIG_BUTTON_LONG_PRESS_TIME_MS /TICKS_INTERVAL)
+#define SERIAL_TICKS      (CONFIG_BUTTON_SERIAL_TIME_MS /TICKS_INTERVAL)
 
 #define CALL_EVENT_CB(ev)   if(btn->cb[ev])btn->cb[ev](btn, btn->usr_data)
 
@@ -145,8 +146,11 @@ static void button_handler(button_dev_t *btn)
     case 5:
         if (btn->button_level == btn->active_level) {
             //continue hold trigger
-            btn->event = (uint8_t)BUTTON_LONG_PRESS_HOLD;
-            CALL_EVENT_CB(BUTTON_LONG_PRESS_HOLD);
+            if (btn->ticks > SERIAL_TICKS) {
+                btn->event = (uint8_t)BUTTON_LONG_PRESS_HOLD;
+                CALL_EVENT_CB(BUTTON_LONG_PRESS_HOLD);
+                btn->ticks = 0;
+            }
         } else { //releasd
             btn->event = (uint8_t)BUTTON_PRESS_UP;
             CALL_EVENT_CB(BUTTON_PRESS_UP);


### PR DESCRIPTION
This adds a serial trigger interval between `BUTTON_LONG_PRESS_HOLD` events similar to the behaviour of the old `iot_button_set_serial_cb()` with `interval_tick` parameter.