### PR TITLE
Add `i2s_lcd_acquire_nonblocking` and minor fixes

### DIFF
--- a/components/bus/i2s_lcd_esp32s2_driver.c
+++ b/components/bus/i2s_lcd_esp32s2_driver.c
@@ -103,7 +103,7 @@ static void lcd_dma_set_int(i2s_lcd_obj_t *i2s_lcd_obj)
         i2s_lcd_obj->dma[x].empty = (uint32_t)&i2s_lcd_obj->dma[(x + 1) % i2s_lcd_obj->dma_node_cnt];
     }
     i2s_lcd_obj->dma[i2s_lcd_obj->dma_half_node_cnt - 1].empty = (uint32_t)NULL;
-    i2s_lcd_obj->dma[i2s_lcd_obj->dma_node_cnt - 1].empty = (uint32_t)NULL; 
+    i2s_lcd_obj->dma[i2s_lcd_obj->dma_node_cnt - 1].empty = (uint32_t)NULL;
 }
 
 static void lcd_dma_set_left(i2s_lcd_obj_t *i2s_lcd_obj, int pos, size_t len)
@@ -285,7 +285,7 @@ static esp_err_t lcd_dma_config(i2s_lcd_obj_t *i2s_lcd_obj, uint32_t max_dma_buf
     i2s_lcd_obj->dma_node_cnt = (i2s_lcd_obj->dma_buffer_size) / i2s_lcd_obj->dma_node_buffer_size; // Number of DMA nodes
     i2s_lcd_obj->dma_half_node_cnt = i2s_lcd_obj->dma_node_cnt / 2;
 
-    ESP_LOGI(TAG, "lcd_buffer_size: %d, lcd_dma_size: %d, lcd_dma_node_cnt: %d", i2s_lcd_obj->dma_buffer_size, i2s_lcd_obj->dma_node_buffer_size, i2s_lcd_obj->dma_node_cnt);
+    ESP_LOGI(TAG, "lcd_buffer_size: %d, lcd_dma_size: %d, lcd_dma_node_cnt: %d", (int)i2s_lcd_obj->dma_buffer_size, (int)i2s_lcd_obj->dma_node_buffer_size, (int)i2s_lcd_obj->dma_node_cnt);
 
     i2s_lcd_obj->dma    = (lldesc_t *)heap_caps_malloc(i2s_lcd_obj->dma_node_cnt * sizeof(lldesc_t), MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
     i2s_lcd_obj->dma_buffer = (uint8_t *)heap_caps_malloc(i2s_lcd_obj->dma_buffer_size * sizeof(uint8_t), MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
@@ -484,6 +484,16 @@ esp_err_t i2s_lcd_release(i2s_lcd_handle_t handle)
     I2S_CHECK(NULL != i2s_lcd_drv, "handle pointer invalid", ESP_ERR_INVALID_ARG);
     BaseType_t ret = xSemaphoreGive(i2s_lcd_drv->mutex);
     I2S_CHECK(pdTRUE == ret, "Give semaphore failed", ESP_FAIL);
+    return ESP_OK;
+}
+
+esp_err_t i2s_lcd_acquire_nonblocking(i2s_lcd_handle_t handle, TickType_t ticks_to_wait, bool *lock_acquired)
+{
+    i2s_lcd_driver_t *i2s_lcd_drv = (i2s_lcd_driver_t *)handle;
+    I2S_CHECK(NULL != i2s_lcd_drv, "handle pointer invalid", ESP_ERR_INVALID_ARG);
+    BaseType_t ret = xSemaphoreTake(i2s_lcd_drv->mutex, ticks_to_wait);
+    I2S_CHECK(pdTRUE == ret, "Take semaphore failed", ESP_FAIL);
+    *lock_acquired = (pdTRUE == ret);
     return ESP_OK;
 }
 

--- a/components/bus/include/i2s_lcd_driver.h
+++ b/components/bus/include/i2s_lcd_driver.h
@@ -28,7 +28,7 @@ typedef void * i2s_lcd_handle_t; /** Handle of i2s lcd driver */
 
 /**
  * @brief Configuration of i2s lcd mode
- * 
+ *
  */
 typedef struct {
     int8_t data_width;           /*!< Parallel data width, 16bit or 8bit available */
@@ -43,7 +43,7 @@ typedef struct {
 } i2s_lcd_config_t;
 
 /**
- * @brief Initilize i2s lcd driver. 
+ * @brief Initilize i2s lcd driver.
  *
  * @param config configuration of i2s
  *
@@ -52,10 +52,10 @@ typedef struct {
 i2s_lcd_handle_t i2s_lcd_driver_init(const i2s_lcd_config_t *config);
 
 /**
- * @brief Deinit i2s lcd driver. 
- * 
+ * @brief Deinit i2s lcd driver.
+ *
  * @param handle i2s lcd driver handle to deinitilize
- * 
+ *
  * @return
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_ARG handle is invalid
@@ -64,10 +64,10 @@ esp_err_t i2s_lcd_driver_deinit(i2s_lcd_handle_t handle);
 
 /**
  * @brief Write a data to LCD
- * 
+ *
  * @param handle i2s lcd driver handle
  * @param data Data to write
- * 
+ *
  * @return
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_ARG handle is invalid
@@ -76,10 +76,10 @@ esp_err_t i2s_lcd_write_data(i2s_lcd_handle_t handle, uint16_t data);
 
 /**
  * @brief Write a command to LCD
- * 
+ *
  * @param handle Handle of i2s lcd driver
  * @param cmd command to write
- * 
+ *
  * @return
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_ARG handle is invalid
@@ -88,11 +88,11 @@ esp_err_t i2s_lcd_write_cmd(i2s_lcd_handle_t handle, uint16_t cmd);
 
 /**
  * @brief Write a command to LCD
- * 
+ *
  * @param handle Handle of i2s lcd driver
  * @param cmd command to write
  * @param length length of command
- * 
+ *
  * @return
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_ARG handle is invalid
@@ -101,11 +101,11 @@ esp_err_t i2s_lcd_write_command(i2s_lcd_handle_t handle, const uint8_t *cmd, uin
 
 /**
  * @brief Write block data to LCD
- * 
- * @param handle  Handle of i2s lcd driver
+ *
+ * @param handle Handle of i2s lcd driver
  * @param data Pointer of data
  * @param length length of data
- * 
+ *
  * @return
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_ARG handle is invalid
@@ -114,22 +114,32 @@ esp_err_t i2s_lcd_write(i2s_lcd_handle_t handle, const uint8_t *data, uint32_t l
 
 /**
  * @brief acquire a lock
- * 
- * @param handle  Handle of i2s lcd driver
- * 
+ *
+ * @param handle Handle of i2s lcd driver
+ *
  * @return Always return ESP_OK
  */
 esp_err_t i2s_lcd_acquire(i2s_lcd_handle_t handle);
 
 /**
  * @brief release a lock
- * 
- * @param handle  Handle of i2s lcd driver
- * 
+ *
+ * @param handle Handle of i2s lcd driver
+ *
  * @return Always return ESP_OK
  */
 esp_err_t i2s_lcd_release(i2s_lcd_handle_t handle);
 
+/**
+ * @brief acquire a lock, but only wait a certain period of time
+ *
+ * @param handle Handle of i2s lcd driver
+ * @param ticks_to_wait waiting period
+ * @param lock_acquired true if the lock was acquired, false otherwise
+ *
+ * @return Always return ESP_OK
+ */
+esp_err_t i2s_lcd_acquire_nonblocking(i2s_lcd_handle_t handle, TickType_t ticks_to_wait, bool *lock_acquired);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds the following function and minor fixes for compiling with idf v5.0.
```c
/**
 * @brief acquire a lock, but only wait a certain period of time
 *
 * @param handle Handle of i2s lcd driver
 * @param ticks_to_wait waiting period
 * @param lock_acquired true if the lock was acquired, false otherwise
 *
 * @return Always return ESP_OK
 */
esp_err_t i2s_lcd_acquire_nonblocking(i2s_lcd_handle_t handle, TickType_t ticks_to_wait, bool *lock_acquired)
{
    i2s_lcd_driver_t *i2s_lcd_drv = (i2s_lcd_driver_t *)handle;
    I2S_CHECK(NULL != i2s_lcd_drv, "handle pointer invalid", ESP_ERR_INVALID_ARG);
    BaseType_t ret = xSemaphoreTake(i2s_lcd_drv->mutex, ticks_to_wait);
    I2S_CHECK(pdTRUE == ret, "Take semaphore failed", ESP_FAIL);
    *lock_acquired = (pdTRUE == ret);
    return ESP_OK;
}
```