### PR TITLE
Fix typo in log TAG

### DIFF
--- a/examples/audio/wav_player/main/app_main.c
+++ b/examples/audio/wav_player/main/app_main.c
@@ -14,7 +14,7 @@
 #include "pwm_audio.h"
 #include "file_manager.h"
 
-static const char *TAG = "wav palyer";
+static const char *TAG = "wav player";
 
 typedef struct {
     // The "RIFF" chunk descriptor


### PR DESCRIPTION
Change TAG name from "wav palyer" to "wav player" in examples/audio/wav_player/main/app_main.c