### PR TITLE
Fix averaging of LCD touchscreen presses to exclude invalid readings

### DIFF
--- a/components/display/touch_panel/ns2016/ns2016.c
+++ b/components/display/touch_panel/ns2016/ns2016.c
@@ -42,6 +42,7 @@ static const char *TAG = "NS2016";
 
 #define TOUCH_SAMPLE_MAX 4000
 #define TOUCH_SAMPLE_MIN 100
+#define TOUCH_SAMPLE_INVALID 0
 
 typedef struct {
     uint16_t x;
@@ -181,8 +182,8 @@ esp_err_t ns2016_get_rawdata(uint16_t *x, uint16_t *y)
         aveX /= valid_count;
         aveY /= valid_count;
     } else {
-        aveX = 1;
-        aveY = 1;
+        aveX = TOUCH_SAMPLE_INVALID;
+        aveY = TOUCH_SAMPLE_INVALID;
     }
 
     *x = aveX;

--- a/components/display/touch_panel/ns2016/ns2016.c
+++ b/components/display/touch_panel/ns2016/ns2016.c
@@ -159,6 +159,7 @@ esp_err_t ns2016_get_rawdata(uint16_t *x, uint16_t *y)
     esp_err_t ret;
     uint32_t aveX = 0;
     uint32_t aveY = 0;
+    int valid_count = 0;
 
     for (int i = 0; i < NS2016_SMP_SIZE; i++) {
         ret = ns2016_get_sample(NS2016_TOUCH_CMD_X, &(samples[i].x));
@@ -166,12 +167,23 @@ esp_err_t ns2016_get_rawdata(uint16_t *x, uint16_t *y)
         ret = ns2016_get_sample(NS2016_TOUCH_CMD_Y, &(samples[i].y));
         TOUCH_CHECK(ret == ESP_OK, "Y sample failed", ESP_FAIL);
 
-        aveX += samples[i].x;
-        aveY += samples[i].y;
+        // Only add the samples to the average if they are valid
+        if ((samples[i].x >= TOUCH_SAMPLE_MIN) && (samples[i].x <= TOUCH_SAMPLE_MAX) &&
+            (samples[i].y >= TOUCH_SAMPLE_MIN) && (samples[i].y <= TOUCH_SAMPLE_MAX)) {
+            aveX += samples[i].x;
+            aveY += samples[i].y;
+            valid_count++;
+        }
     }
 
-    aveX /= NS2016_SMP_SIZE;
-    aveY /= NS2016_SMP_SIZE;
+    // If we don't have at least 50% valid samples, there was no valid touch.
+    if (valid_count >= (NS2016_SMP_SIZE / 2)) {
+        aveX /= valid_count;
+        aveY /= valid_count;
+    } else {
+        aveX = 1;
+        aveY = 1;
+    }
 
     *x = aveX;
     *y = aveY;

--- a/components/display/touch_panel/xpt2046/xpt2046.c
+++ b/components/display/touch_panel/xpt2046/xpt2046.c
@@ -157,6 +157,7 @@ esp_err_t xpt2046_get_rawdata(uint16_t *x, uint16_t *y)
     esp_err_t ret;
     uint32_t aveX = 0;
     uint32_t aveY = 0;
+    int valid_count = 0;
 
     for (int i = 0; i < XPT2046_SMP_SIZE; i++) {
         ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_X, &(samples[i].x));
@@ -164,12 +165,23 @@ esp_err_t xpt2046_get_rawdata(uint16_t *x, uint16_t *y)
         ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Y, &(samples[i].y));
         TOUCH_CHECK(ret == ESP_OK, "Y sample failed", ESP_FAIL);
 
-        aveX += samples[i].x;
-        aveY += samples[i].y;
+        // Only add the samples to the average if they are valid
+        if ((samples[i].x >= TOUCH_SAMPLE_MIN) && (samples[i].x <= TOUCH_SAMPLE_MAX) &&
+            (samples[i].y >= TOUCH_SAMPLE_MIN) && (samples[i].y <= TOUCH_SAMPLE_MAX)) {
+            aveX += samples[i].x;
+            aveY += samples[i].y;
+            valid_count++;
+        }
     }
 
-    aveX /= XPT2046_SMP_SIZE;
-    aveY /= XPT2046_SMP_SIZE;
+    // If we don't have at least 50% valid samples, there was no valid touch.
+    if (valid_count >= (XPT2046_SMP_SIZE / 2)) {
+        aveX /= valid_count;
+        aveY /= valid_count;
+    } else {
+        aveX = 1;
+        aveY = 1;
+    }
 
     *x = aveX;
     *y = aveY;

--- a/components/display/touch_panel/xpt2046/xpt2046.c
+++ b/components/display/touch_panel/xpt2046/xpt2046.c
@@ -32,6 +32,7 @@ static const char *TAG = "XPT2046";
 
 #define TOUCH_SAMPLE_MAX 4000
 #define TOUCH_SAMPLE_MIN 100
+#define TOUCH_SAMPLE_INVALID 0
 
 #define XPT2046_THRESHOLD_Z CONFIG_TOUCH_PANEL_THRESHOLD_PRESS
 
@@ -179,8 +180,8 @@ esp_err_t xpt2046_get_rawdata(uint16_t *x, uint16_t *y)
         aveX /= valid_count;
         aveY /= valid_count;
     } else {
-        aveX = 1;
-        aveY = 1;
+        aveX = TOUCH_SAMPLE_INVALID;
+        aveY = TOUCH_SAMPLE_INVALID;
     }
 
     *x = aveX;


### PR DESCRIPTION
The drivers for the NS2016 SPI Resistive touchscreen driver and the XPT2046 SPI Resistive touchscreen driver apply a 4 sample average to the touch readings. This means that if a touch is released during the sampling interval, the returned position is corrupted by invalid readings. This means that often when releasing the touchscreen, the position will get 'dragged' or 'torn' towards one corner, and thus presses often trigger a different object than intended.

This patch changes the behaviour to validate the samples individually, rejecting invalid samples, and if there are more than 50% invalid samples they will return no touch. This stabilises the touch behaviour to ensure that the pressed object is the one intended.