### PR TITLE
Extend XPT2046 touch driver to add temperature, batt voltage, aux input voltage read support

### DIFF
--- a/components/display/touch_panel/xpt2046/xpt2046.c
+++ b/components/display/touch_panel/xpt2046/xpt2046.c
@@ -286,6 +286,7 @@ esp_err_t xpt2046_get_temp_deg_c(float* temperature)
 
     // First reading is to turn on the Vref
     ret = xpt2046_get_sample(XPT2046_TEMP0_CMD, &temp0);
+    TOUCH_CHECK(ESP_OK == ret, "Vref turn on failed", ESP_FAIL);
     // Second reading is to get the result
     ret = xpt2046_get_sample(XPT2046_TEMP0_CMD, &temp0);
     TOUCH_CHECK(ESP_OK == ret, "Temp0 read failed", ESP_FAIL);
@@ -296,6 +297,7 @@ esp_err_t xpt2046_get_temp_deg_c(float* temperature)
 
     // Last reading is to turn off the Vref
     ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Z1, &temp0);
+    TOUCH_CHECK(ESP_OK == ret, "Vref turn off failed", ESP_FAIL);
 
     return ESP_OK;
 }
@@ -307,6 +309,7 @@ esp_err_t xpt2046_get_batt_v(float* voltage)
 
     // First reading is to turn on the Vref
     ret = xpt2046_get_sample(XPT2046_VBAT_CMD, &vbat);
+    TOUCH_CHECK(ESP_OK == ret, "Vref turn on failed", ESP_FAIL);
     // Second reading is to get the result
     ret = xpt2046_get_sample(XPT2046_VBAT_CMD, &vbat);
     TOUCH_CHECK(ESP_OK == ret, "Vbat read failed", ESP_FAIL);
@@ -315,6 +318,7 @@ esp_err_t xpt2046_get_batt_v(float* voltage)
 
     // Last reading is to turn off the Vref
     ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Z1, &vbat);
+    TOUCH_CHECK(ESP_OK == ret, "Vref turn off failed", ESP_FAIL);
 
     return ESP_OK;
 }
@@ -326,6 +330,7 @@ esp_err_t xpt2046_get_aux_v(float* voltage)
 
     // First reading is to turn on the Vref
     ret = xpt2046_get_sample(XPT2046_AUXIN_CMD, &vin);
+    TOUCH_CHECK(ESP_OK == ret, "Vref turn on failed", ESP_FAIL);
     // Second reading is to get the result
     ret = xpt2046_get_sample(XPT2046_AUXIN_CMD, &vin);
     TOUCH_CHECK(ESP_OK == ret, "Aux read failed", ESP_FAIL);
@@ -334,6 +339,7 @@ esp_err_t xpt2046_get_aux_v(float* voltage)
 
     // Last reading is to turn off the Vref
     ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Z1, &vin);
+    TOUCH_CHECK(ESP_OK == ret, "Vref turn off failed", ESP_FAIL);
 
     return ESP_OK;
 }

--- a/components/display/touch_panel/xpt2046/xpt2046.c
+++ b/components/display/touch_panel/xpt2046/xpt2046.c
@@ -24,6 +24,10 @@ static const char *TAG = "XPT2046";
         return (ret);                                                                   \
     }
 
+#define XPT2046_TEMP0_CMD     0b10000110
+#define XPT2046_TEMP1_CMD     0b11110110
+#define XPT2046_VBAT_CMD      0b10100110
+#define XPT2046_AUXIN_CMD     0b11100110
 #define XPT2046_TOUCH_CMD_X   0xD0
 #define XPT2046_TOUCH_CMD_Y   0x90
 #define XPT2046_TOUCH_CMD_Z1  0b10110000
@@ -34,6 +38,8 @@ static const char *TAG = "XPT2046";
 #define TOUCH_SAMPLE_MIN 100
 
 #define XPT2046_THRESHOLD_Z CONFIG_TOUCH_PANEL_THRESHOLD_PRESS
+
+#define XPT2046_TEMP0_COUNTS_AT_25C   (599.5 / 2507 * 4095)
 
 typedef struct {
     uint16_t x;
@@ -271,4 +277,63 @@ esp_err_t xpt2046_sample(touch_panel_points_t *info)
 esp_err_t xpt2046_calibration_run(const scr_driver_t *screen, bool recalibrate)
 {
     return touch_calibration_run(screen, xpt2046_is_pressed, xpt2046_get_rawdata, recalibrate);
+}
+
+esp_err_t xpt2046_get_temp_deg_c(float* temperature)
+{
+    esp_err_t ret;
+    uint16_t temp0;
+
+    // First reading is to turn on the Vref
+    ret = xpt2046_get_sample(XPT2046_TEMP0_CMD, &temp0);
+    // Second reading is to get the result
+    ret = xpt2046_get_sample(XPT2046_TEMP0_CMD, &temp0);
+    TOUCH_CHECK(ESP_OK == ret, "Temp0 read failed", ESP_FAIL);
+
+    // 12 bit = 4095 counts. 2.507V full scale internal reference. 0.0021V/degC characteristic.
+    //  599.5mV @25degC nominal
+    *temperature = (float) (XPT2046_TEMP0_COUNTS_AT_25C - temp0) * (2.507 / 4095.0) / 0.0021 + 25.0;
+
+    // Last reading is to turn off the Vref
+    ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Z1, &temp0);
+
+    return ESP_OK;
+}
+
+esp_err_t xpt2046_get_batt_v(float* voltage)
+{
+    esp_err_t ret;
+    uint16_t vbat;
+
+    // First reading is to turn on the Vref
+    ret = xpt2046_get_sample(XPT2046_VBAT_CMD, &vbat);
+    // Second reading is to get the result
+    ret = xpt2046_get_sample(XPT2046_VBAT_CMD, &vbat);
+    TOUCH_CHECK(ESP_OK == ret, "Vbat read failed", ESP_FAIL);
+
+    *voltage = (float) vbat * (2.507 / 4095.0) * 4.0;
+
+    // Last reading is to turn off the Vref
+    ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Z1, &vbat);
+
+    return ESP_OK;
+}
+
+esp_err_t xpt2046_get_aux_v(float* voltage)
+{
+    esp_err_t ret;
+    uint16_t vin;
+
+    // First reading is to turn on the Vref
+    ret = xpt2046_get_sample(XPT2046_AUXIN_CMD, &vin);
+    // Second reading is to get the result
+    ret = xpt2046_get_sample(XPT2046_AUXIN_CMD, &vin);
+    TOUCH_CHECK(ESP_OK == ret, "Aux read failed", ESP_FAIL);
+
+    *voltage = (float) vin * (2.507 / 4095.0);
+
+    // Last reading is to turn off the Vref
+    ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Z1, &vin);
+
+    return ESP_OK;
 }

--- a/components/display/touch_panel/xpt2046/xpt2046.h
+++ b/components/display/touch_panel/xpt2046/xpt2046.h
@@ -99,6 +99,39 @@ esp_err_t xpt2046_calibration_run(const scr_driver_t *screen, bool recalibrate);
  */
 esp_err_t xpt2046_sample(touch_panel_points_t* info);
 
+/**
+ * @brief Get the temperature from the touchscreen controller
+ *
+ * @param temperature a pointer to a float to store the temperature in degrees C
+ *
+ * @return
+ *     - ESP_OK Success
+ *     - ESP_FAIL Fail
+ */
+esp_err_t xpt2046_get_temp_deg_c(float* temperature);
+
+/**
+ * @brief Get the temperature from the touchscreen controller
+ *
+ * @param temperature a pointer to a float to store the temperature in degrees C
+ *
+ * @return
+ *     - ESP_OK Success
+ *     - ESP_FAIL Fail
+ */
+esp_err_t xpt2046_get_batt_v(float* temperature);
+
+/**
+ * @brief Get the temperature from the touchscreen controller
+ *
+ * @param temperature a pointer to a float to store the temperature in degrees C
+ *
+ * @return
+ *     - ESP_OK Success
+ *     - ESP_FAIL Fail
+ */
+esp_err_t xpt2046_get_aux_v(float* temperature);
+
 
 #ifdef __cplusplus
 }

--- a/components/display/touch_panel/xpt2046/xpt2046.h
+++ b/components/display/touch_panel/xpt2046/xpt2046.h
@@ -111,26 +111,26 @@ esp_err_t xpt2046_sample(touch_panel_points_t* info);
 esp_err_t xpt2046_get_temp_deg_c(float* temperature);
 
 /**
- * @brief Get the temperature from the touchscreen controller
+ * @brief Get the voltage on the battery pin from the touchscreen controller
  *
- * @param temperature a pointer to a float to store the temperature in degrees C
+ * @param voltage a pointer to a float to store the voltage in V
  *
  * @return
  *     - ESP_OK Success
  *     - ESP_FAIL Fail
  */
-esp_err_t xpt2046_get_batt_v(float* temperature);
+esp_err_t xpt2046_get_batt_v(float* voltage);
 
 /**
- * @brief Get the temperature from the touchscreen controller
+ * @brief Get the voltage on the aux pin from the touchscreen controller
  *
- * @param temperature a pointer to a float to store the temperature in degrees C
+ * @param voltage a pointer to a float to store the voltage in V
  *
  * @return
  *     - ESP_OK Success
  *     - ESP_FAIL Fail
  */
-esp_err_t xpt2046_get_aux_v(float* temperature);
+esp_err_t xpt2046_get_aux_v(float* voltage);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
The XPT2046 touch controller chip (and variants) supports reading temperature, battery voltage and auxiliary input voltage.

This patch extends the XPT2046 driver with functions to read these values. Tested with the TSC2046 chip (equivalent).