### PR TITLE
Add test IRQ line to detect touch controller press (AEGHB-6)

### DIFF
--- a/components/display/touch_panel/ft5x06/ft5x06.c
+++ b/components/display/touch_panel/ft5x06/ft5x06.c
@@ -245,15 +245,9 @@ int ft5x06_is_press(void)
      * 1. Read the IRQ line of touch controller
      * 2. Read number of points touched in the register
      */
-    if (-1 != g_dev.pin_num_int) {
-        /**
-         * @note Detect the no touch case using the IRQ line
-         * If a touch is detected, fall through to read the register to confirm no multi touch
-         */
-        if (gpio_get_level((gpio_num_t)g_dev.pin_num_int)) {
-            return 0;
-            }
-        }
+    if (-1 != g_touch_dev.pin_num_int) {
+        return !gpio_get_level((gpio_num_t)g_touch_dev.pin_num_int);
+    }
     uint8_t points;
     ft5x06_read_reg(&g_dev, FT5x06_TOUCH_POINTS, &points);
     if (points != 1) {    // ignore no touch & multi touch

--- a/components/display/touch_panel/ft5x06/ft5x06.c
+++ b/components/display/touch_panel/ft5x06/ft5x06.c
@@ -240,6 +240,20 @@ esp_err_t ft5x06_set_direction(touch_panel_dir_t dir)
 
 int ft5x06_is_press(void)
 {
+    /**
+     * @note There are two ways to determine weather the touch panel is pressed
+     * 1. Read the IRQ line of touch controller
+     * 2. Read number of points touched in the register
+     */
+    if (-1 != g_dev.pin_num_int) {
+        /**
+         * @note Detect the no touch case using the IRQ line
+         * If a touch is detected, fall through to read the register to confirm no multi touch
+         */
+        if (gpio_get_level((gpio_num_t)g_dev.pin_num_int)) {
+            return 0;
+            }
+        }
     uint8_t points;
     ft5x06_read_reg(&g_dev, FT5x06_TOUCH_POINTS, &points);
     if (points != 1) {    // ignore no touch & multi touch

--- a/components/display/touch_panel/ns2016/ns2016.c
+++ b/components/display/touch_panel/ns2016/ns2016.c
@@ -134,8 +134,8 @@ int ns2016_is_pressed(void)
      * 2. Read value of z axis
      */
     if (-1 != g_touch_dev.pin_num_int) {
-      return !gpio_get_level((gpio_num_t)g_touch_dev.pin_num_int);
-      }
+        return !gpio_get_level((gpio_num_t)g_touch_dev.pin_num_int);
+    }
     uint16_t z;
     esp_err_t ret = ns2016_get_sample(NS2016_TOUCH_CMD_Z1, &z);
     TOUCH_CHECK(ret == ESP_OK, "Z sample failed", 0);

--- a/components/display/touch_panel/ns2016/ns2016.c
+++ b/components/display/touch_panel/ns2016/ns2016.c
@@ -132,8 +132,10 @@ int ns2016_is_pressed(void)
      * @note There are two ways to determine weather the touch panel is pressed
      * 1. Read the IRQ line of touch controller
      * 2. Read value of z axis
-     * Only the second method is used here, so the IRQ line is not used.
      */
+    if (-1 != g_touch_dev.pin_num_int) {
+      return !gpio_get_level((gpio_num_t)g_touch_dev.pin_num_int);
+      }
     uint16_t z;
     esp_err_t ret = ns2016_get_sample(NS2016_TOUCH_CMD_Z1, &z);
     TOUCH_CHECK(ret == ESP_OK, "Z sample failed", 0);

--- a/components/display/touch_panel/touch_panel.h
+++ b/components/display/touch_panel/touch_panel.h
@@ -149,7 +149,7 @@ typedef struct {
     };
 
     touch_panel_interface_type_t interface_type;   /*!< Interface bus type, see touch_interface_type_t struct */
-    int8_t pin_num_int;                            /*!< Interrupt pin of touch panel. NOTE: Now this line is not used, you can set to -1 and no connection with hardware */
+    int8_t pin_num_int;                            /*!< Interrupt pin of touch panel. NOTE: You can set to -1 for no connection with hardware. If PENIRQ is connected set this to pin number. */
     touch_panel_dir_t direction;                   /*!< Rotate direction */
     uint16_t width;                                /*!< touch panel width */
     uint16_t height;                               /*!< touch panel height */

--- a/components/display/touch_panel/touch_panel.h
+++ b/components/display/touch_panel/touch_panel.h
@@ -149,7 +149,7 @@ typedef struct {
     };
 
     touch_panel_interface_type_t interface_type;   /*!< Interface bus type, see touch_interface_type_t struct */
-    int8_t pin_num_int;                            /*!< Interrupt pin of touch panel. NOTE: You can set to -1 for no connection with hardware. If PENIRQ is connected set this to pin number. */
+    int8_t pin_num_int;                            /*!< Interrupt pin of touch panel. NOTE: You can set to -1 for no connection with hardware. If PENIRQ is connected, set this to pin number. */
     touch_panel_dir_t direction;                   /*!< Rotate direction */
     uint16_t width;                                /*!< touch panel width */
     uint16_t height;                               /*!< touch panel height */

--- a/components/display/touch_panel/xpt2046/xpt2046.c
+++ b/components/display/touch_panel/xpt2046/xpt2046.c
@@ -130,8 +130,10 @@ int xpt2046_is_pressed(void)
      * @note There are two ways to determine weather the touch panel is pressed
      * 1. Read the IRQ line of touch controller
      * 2. Read value of z axis
-     * Only the second method is used here, so the IRQ line is not used.
      */
+    if (-1 != g_dev.io_irq) {
+      return !gpio_get_level((gpio_num_t)g_dev.io_irq);
+      }
     uint16_t z;
     esp_err_t ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Z1, &z);
     TOUCH_CHECK(ret == ESP_OK, "Z sample failed", 0);

--- a/components/display/touch_panel/xpt2046/xpt2046.c
+++ b/components/display/touch_panel/xpt2046/xpt2046.c
@@ -132,8 +132,8 @@ int xpt2046_is_pressed(void)
      * 2. Read value of z axis
      */
     if (-1 != g_dev.io_irq) {
-      return !gpio_get_level((gpio_num_t)g_dev.io_irq);
-      }
+        return !gpio_get_level((gpio_num_t)g_dev.io_irq);
+    }
     uint16_t z;
     esp_err_t ret = xpt2046_get_sample(XPT2046_TOUCH_CMD_Z1, &z);
     TOUCH_CHECK(ret == ESP_OK, "Z sample failed", 0);


### PR DESCRIPTION
The XPT2046 and NS2016 chips provide an interrupt output for testing whether there is an active screen touch.

This PR adds optional support for reading this signal using a GPIO line, reducing traffic on the SPI bus. Simply configure the pin_num_int value in the touch_panel_config_t struct to be the GPIO number connected to the interrupt line, or set to -1 if not connected.