### PR TITLE
Fix allocation of LVGL display buffer memory when <60kB memory remaining (AEGHB-5)

### DIFF
--- a/components/gui/lvgl_gui/Kconfig
+++ b/components/gui/lvgl_gui/Kconfig
@@ -466,7 +466,7 @@ menu "LVGL configuration"
     endmenu
 
     menu "Theme usage"
-	menu "Enable theme usage, always enable at least one theme"
+        menu "Enable theme usage, always enable at least one theme"
             config LVGL_THEME_EMPTY
                     bool
                     prompt "Empty: No theme, you can apply your styles as you need."
@@ -480,7 +480,7 @@ menu "LVGL configuration"
             config LVGL_THEME_MONO
                     bool
                     prompt "Mono: Mono-color theme for monochrome displays"
-	endmenu
+        endmenu
 
         choice LVGL_THEME_DEFAULT_INIT
             prompt "Select theme default init"
@@ -629,13 +629,43 @@ menu "LVGL configuration"
     endmenu
 
     menu "Memory manager settings"
-	config LVGL_MEM_SIZE
-	    int
-	    prompt "Size of the memory used by `lv_mem_alloc` in kilobytes (>= 2kB)"
-	    range 2 128
-	    default 32
+        config LVGL_MEM_SIZE
+            int
+            prompt "Size of the memory used by `lv_mem_alloc` in kilobytes (>= 2kB)"
+            range 2 128
+            default 32
+
+        config LVGL_MEM_REMAIN_SIZE
+            int
+            prompt "Aspirational minimum amount of memory to leave available for other functions when allocating display buffer"
+            range 2 80
+            default 60
     endmenu
 
+    menu "LVGL Task settings"
+        config LVGL_TASK_MEM_SIZE
+            int
+            prompt "Size of the memory allocated to the LV GUI task in kilobytes (>= 2kB)"
+            range 2 16
+            default 8
+
+        config LVGL_TASK_PRIORITY
+            int
+            prompt "Priority of the LVGL GUI task"
+            range 1 24
+            default 5
+
+        choice LVGL_TASK_CORE_AFFINITY
+            prompt "Core affinity of the LVGL GUI task"
+            default LVGL_TASK_CORE_AFFINITY_CPU1
+            config LVGL_TASK_CORE_AFFINITY_CPU0
+                bool "LVGL task on CPU0/PRO"
+            config LVGL_TASK_CORE_AFFINITY_CPU1
+                bool "LVGL task on CPU1/APP"
+            config LVGL_TASK_CORE_AFFINITY_NONE
+                bool "LVGL task has no affinity"
+        endchoice
+    endmenu
 
     menu "Log Settings"
         config LVGL_USE_LOG

--- a/components/gui/lvgl_gui/lvgl_gui.c
+++ b/components/gui/lvgl_gui/lvgl_gui.c
@@ -79,9 +79,19 @@ static esp_err_t lvgl_display_init(scr_driver_t *driver)
     disp_drv.flush_cb = ex_disp_flush; /*Used in buffered mode (LV_VDB_SIZE != 0  in lv_conf.h)*/
 
     size_t free_size = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    const size_t remain_size = 60 * 1024; /**< Remain for other functions */
+    size_t remain_size = CONFIG_LVGL_MEM_REMAIN_SIZE * 1024; /**< Remain for other functions */
     size_t alloc_pixel = DISP_BUF_SIZE;
     if (((BUFFER_NUMBER * PIXEL_TO_SIZE(alloc_pixel)) + remain_size) > free_size) {
+        if ((remain_size > free_size) || (free_size / 2 > alloc_pixel)) {
+            ESP_LOGW(TAG, "Free size = %d Bytes, Initial remain size = %d Bytes", free_size, remain_size);
+            // If we can't leave 60k of spare memory, just leave half of whatever is left.
+            remain_size = free_size / 2;
+            ESP_LOGW(TAG, "Final remain size = %d Bytes", remain_size);
+        }
+        if (alloc_pixel > DISP_BUF_SIZE) {
+            // If half the remaining memory is more than we originally planned to allocate, just stick with the original plan.
+            alloc_pixel = DISP_BUF_SIZE;
+        }
         size_t allow_size = (free_size - remain_size) & 0xfffffffc;
         alloc_pixel = SIZE_TO_PIXEL(allow_size / BUFFER_NUMBER);
         ESP_LOGW(TAG, "Exceeded max free size, force shrink to %u Byte", allow_size);
@@ -204,10 +214,12 @@ esp_err_t lvgl_init(scr_driver_t *lcd_drv, touch_panel_driver_t *touch_drv)
     xGuiSemaphore = xSemaphoreCreateMutex();
     ESP_GOTO_ON_FALSE(NULL != xGuiSemaphore, ESP_FAIL, err, TAG, "Create mutex for LVGL failed");
 
-#if CONFIG_FREERTOS_UNICORE == 0
-    int err = xTaskCreatePinnedToCore(gui_task, "lv gui", 1024 * 8, NULL, 5, &g_lvgl_task_handle, 1);
-#else
-    int err = xTaskCreatePinnedToCore(gui_task, "lv gui", 1024 * 8, NULL, 5, &g_lvgl_task_handle, 0);
+#if CONFIG_FREERTOS_UNICORE || CONFIG_LVGL_TASK_CORE_AFFINITY_CPU0
+    int err = xTaskCreatePinnedToCore(gui_task, "lv gui", 1024 * CONFIG_LVGL_TASK_MEM_SIZE, NULL, CONFIG_LVGL_TASK_PRIORITY, &g_lvgl_task_handle, 0);
+#elif CONFIG_LVGL_TASK_CORE_AFFINITY_CPU1
+    int err = xTaskCreatePinnedToCore(gui_task, "lv gui", 1024 * CONFIG_LVGL_TASK_MEM_SIZE, NULL, CONFIG_LVGL_TASK_PRIORITY, &g_lvgl_task_handle, 1);
+#elif CONFIG_LVGL_TASK_CORE_AFFINITY_NONE
+    int err = xTaskCreatePinnedToCore(gui_task, "lv gui", 1024 * CONFIG_LVGL_TASK_MEM_SIZE, NULL, CONFIG_LVGL_TASK_PRIORITY, &g_lvgl_task_handle, tskNO_AFFINITY);
 #endif
     ESP_GOTO_ON_FALSE(pdPASS == err, ESP_FAIL, err, TAG, "Create task for LVGL failed");
 

--- a/components/gui/lvgl_gui/lvgl_gui.c
+++ b/components/gui/lvgl_gui/lvgl_gui.c
@@ -88,13 +88,15 @@ static esp_err_t lvgl_display_init(scr_driver_t *driver)
             remain_size = free_size / 2;
             ESP_LOGW(TAG, "Final remain size = %d Bytes", remain_size);
         }
+        size_t allow_size = (free_size - remain_size) & 0xfffffffc;
+        alloc_pixel = SIZE_TO_PIXEL(allow_size / BUFFER_NUMBER);
         if (alloc_pixel > DISP_BUF_SIZE) {
             // If half the remaining memory is more than we originally planned to allocate, just stick with the original plan.
             alloc_pixel = DISP_BUF_SIZE;
         }
-        size_t allow_size = (free_size - remain_size) & 0xfffffffc;
-        alloc_pixel = SIZE_TO_PIXEL(allow_size / BUFFER_NUMBER);
-        ESP_LOGW(TAG, "Exceeded max free size, force shrink to %u Byte", allow_size);
+        else {
+            ESP_LOGW(TAG, "Exceeded max free size, force shrink to %u Byte", allow_size);
+        }
     }
 
     lv_color_t *buf1 = heap_caps_malloc(PIXEL_TO_SIZE(alloc_pixel), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);


### PR DESCRIPTION
The LVGL initialisation code fails catastrophically when the available internal memory is below 60kB. When allocating the display buffer memory, it tries to leave 60kB free, doesn't handle the wraparaound from 55kB-60kB or similar, and tries to allocate way more memory than ever exists.

This PR changes the behaviour to check whether there is sufficient memory available to leave (60kB - amount now configurable) available, and if not, splits the different and allocates half of the remaining memory to the display buffer.

It also adds the option to configure the amount of stack allocated to the LVGL task (the default of 8kB is overkill in many applications), the priority of the LVGL task, and the core affinity of the LVGL task. The default values remain the same.