### PR TITLE
Fix the multi-thread access error caused by usbh_cdc_driver_delete()

### DIFF
--- a/components/usb/esp_usbh_cdc/esp_usbh_cdc.c
+++ b/components/usb/esp_usbh_cdc/esp_usbh_cdc.c
@@ -611,6 +611,7 @@ esp_err_t usbh_cdc_driver_delete(void)
         }
     }
 
+    s_cdc_instance.state = CDC_STATE_NONE;
     if (s_cdc_instance.port_hdl) {
         esp_usbh_port_deinit(s_cdc_instance.port_hdl);
         s_cdc_instance.port_hdl = NULL;
@@ -626,7 +627,6 @@ esp_err_t usbh_cdc_driver_delete(void)
     }
 
     vEventGroupDelete(s_cdc_instance.event_group_hdl);
-    s_cdc_instance.state = CDC_STATE_NONE;
     memset(&s_cdc_instance, 0, sizeof(_class_cdc_t));;
     ESP_LOGI(TAG, "CDC Driver Deleted!");
     return ESP_OK;


### PR DESCRIPTION
**Examples of resource access exceptions caused by multi-task switching are as follows(See the comments in the function):**
```
esp_err_t usbh_cdc_driver_delete(void)
{
    if (!_cdc_driver_is_init()) {
        ESP_LOGW(TAG, "cdc driver not installed");
        return ESP_ERR_INVALID_STATE;
    }
    xEventGroupSetBits(s_cdc_instance.event_group_hdl, CDC_DATA_TASK_KILL_BIT);
    ESP_LOGI(TAG, "Waiting for CDC Driver Delete");
    int counter = TIMEOUT_USB_DRIVER_MS;
    while (xEventGroupGetBits(s_cdc_instance.event_group_hdl) & CDC_DATA_TASK_KILL_BIT) {
        vTaskDelay(pdMS_TO_TICKS(TIMEOUT_USB_DRIVER_CHECK_MS));
        counter -= TIMEOUT_USB_DRIVER_CHECK_MS;
        if (counter <= 0) {
            ESP_LOGW(TAG, "Waiting for CDC Driver Delete, timeout");
            break;
        }
    }

    if (s_cdc_instance.port_hdl) {
        esp_usbh_port_deinit(s_cdc_instance.port_hdl);
        s_cdc_instance.port_hdl = NULL;
    }

    for (size_t i = 0; i < s_cdc_instance.itf_num; i++) {
        if (s_cdc_instance.out_ringbuf_handle[i]) {
            vRingbufferDelete(s_cdc_instance.out_ringbuf_handle[i]);
        }
        if (s_cdc_instance.in_ringbuf_handle[i]) {
            vRingbufferDelete(s_cdc_instance.in_ringbuf_handle[i]);
        }
    }

    vEventGroupDelete(s_cdc_instance.event_group_hdl);
    /* If the task is switched out at this time... */
    s_cdc_instance.state = CDC_STATE_NONE;
    memset(&s_cdc_instance, 0, sizeof(_class_cdc_t));;
    ESP_LOGI(TAG, "CDC Driver Deleted!");
    return ESP_OK;
}
```

```
esp_err_t usbh_cdc_itf_get_buffered_data_len(uint8_t itf, size_t *size)
{
    ERR_CHECK(size != NULL && itf < CDC_INTERFACE_NUM_MAX, "arg can't be NULL", ESP_ERR_INVALID_ARG);

    /* If the task is switched in at this time... */
    if (_cdc_driver_is_init() == false) {
        *size = 0;
        return ESP_ERR_INVALID_STATE;
    }

    if (usbh_cdc_get_itf_state(itf) == false) {
        *size = 0;
        return ESP_ERR_INVALID_STATE;
    }
    vRingbufferGetInfo(s_cdc_instance.in_ringbuf_handle[itf], NULL, NULL, NULL, NULL, size);
    return ESP_OK;
}
```

**Therefore, it is better to do a good job of marking before releasing resources.**