### PR TITLE
Avoid overwriting callback (AEGHB-92)

### DIFF
--- a/components/button/include/iot_button.h
+++ b/components/button/include/iot_button.h
@@ -110,6 +110,7 @@ esp_err_t iot_button_delete(button_handle_t btn_handle);
  * @return
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_ARG   Arguments is invalid.
+ *      - ESP_ERR_INVALID_STATE the Callback is already registered. No free Space for another Callback.
  */
 esp_err_t iot_button_register_cb(button_handle_t btn_handle, button_event_t event, button_cb_t cb, void *usr_data);
 

--- a/components/button/iot_button.c
+++ b/components/button/iot_button.c
@@ -326,6 +326,7 @@ esp_err_t iot_button_register_cb(button_handle_t btn_handle, button_event_t even
     BTN_CHECK(NULL != btn_handle, "Pointer of handle is invalid", ESP_ERR_INVALID_ARG);
     BTN_CHECK(event < BUTTON_EVENT_MAX, "event is invalid", ESP_ERR_INVALID_ARG);
     button_dev_t *btn = (button_dev_t *) btn_handle;
+    BTN_CHECK(NULL == btn->cb[event], "Callback is already registered", ESP_ERR_INVALID_STATE);
     btn->cb[event] = cb;
     btn->usr_data[event] = usr_data;
     return ESP_OK;


### PR DESCRIPTION
ESP_ERR_INVALID_STATE the Callback is already registered. No free Space for another Callback.