### PR TITLE
Fix the control error of pwm_audio in esp-idf-v5 (AEGHB-102)

### DIFF
--- a/components/audio/pwm_audio/pwm_audio.c
+++ b/components/audio/pwm_audio/pwm_audio.c
@@ -777,6 +777,7 @@ esp_err_t pwm_audio_stop(void)
     /**< timer disable interrupt */
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     gptimer_stop(g_gptimer);
+    gptimer_disable(g_gptimer);
 #else
     timer_disable_intr(handle->config.tg_num, handle->config.timer_num);
 #endif


### PR DESCRIPTION
To ensure proper control of pwm_audio_start()and pwm_audio_stop(), gptimer_disable() should be called in the stop method.