### PR TITLE
Set "event" member to BUTTON_PRESS_REPEAT (AEGHB-312)

### DIFF
--- a/components/button/iot_button.c
+++ b/components/button/iot_button.c
@@ -115,6 +115,7 @@ static void button_handler(button_dev_t *btn)
         if (btn->button_level == btn->active_level) {
             btn->event = (uint8_t)BUTTON_PRESS_DOWN;
             CALL_EVENT_CB(BUTTON_PRESS_DOWN);
+            btn->event = (uint8_t)BUTTON_PRESS_REPEAT;
             btn->repeat++;
             CALL_EVENT_CB(BUTTON_PRESS_REPEAT); // repeat hit
             btn->ticks = 0;


### PR DESCRIPTION
Before calling the BUTTON_PRESS_REPEAT callback, the "event" member should be set to "BUTTON_PRESS_REPEAT".

This is currently missing.

If you try "triple clicking" a button, the event member should be set to the
current event. This way if you're callback is meant to handle multiple event
types, you'll be able to distinguish the "BUTTON_PRESS_REPEAT" event from
the preceding "BUTTON_PRESS_DOWN" event.
