### PR TITLE
feat: add support for custom OpenAI base URLs (AEGHB-450)

### DIFF
--- a/components/openai/OpenAI.c
+++ b/components/openai/OpenAI.c
@@ -2242,7 +2242,7 @@ static char *OpenAI_Post(const char *base_url, const char *api_key, const char *
     return OpenAI_Request(base_url, api_key, endpoint, "application/json", HTTP_METHOD_POST, NULL, (uint8_t *)jsonBody, strlen(jsonBody));
 }
 
-static char *OpenAI_get(const char *base_url, const char *api_key, const char *endpoint)
+static char *OpenAI_Get(const char *base_url, const char *api_key, const char *endpoint)
 {
     char *url = malloc(strlen(base_url ? base_url : OPENAI_DEFAULT_BASE_URL) + strlen(endpoint) + 1);
     sprintf(url, "%s%s", base_url ? base_url : OPENAI_DEFAULT_BASE_URL, endpoint);
@@ -2250,7 +2250,7 @@ static char *OpenAI_get(const char *base_url, const char *api_key, const char *e
     return OpenAI_Request(api_key, endpoint, "application/json", HTTP_METHOD_GET, NULL, NULL, 0);
 }
 
-static char *OpenAI_del(const char *base_url, const char *api_key, const char *endpoint)
+static char *OpenAI_Del(const char *base_url, const char *api_key, const char *endpoint)
 {
     char *url = malloc(strlen(base_url ? base_url : OPENAI_DEFAULT_BASE_URL) + strlen(endpoint) + 1);
     sprintf(url, "%s%s", base_url ? base_url : OPENAI_DEFAULT_BASE_URL, endpoint);


### PR DESCRIPTION
This PR is intended to add support for providing a custom OpenAI compatible API endpoint.

Many LLM servers people run locally or within their network can expose an OpenAI compatible API, as such you usually update the "base url" to point to your server.

Examples of such projects include the popular:

- [oobabooga/text-generation-webui@main/extensions/openai](https://github.com/oobabooga/text-generation-webui/tree/main/extensions/openai?rgh-link-date=2023-11-08T11%3A19%3A39Z)
- [localai.io/features/openai-functions](https://localai.io/features/openai-functions/) / [localai.io/howtos/easy-request-openai](https://localai.io/howtos/easy-request-openai/)
- [lmstudio.ai](https://lmstudio.ai/)

There’s also integration libraries like LiteLLM which basically means any project that uses it automatically gets an openAI compatible API: [BerriAI/litellm](https://github.com/BerriAI/litellm)

Please do verify my logic as I am not experienced with C and as such relied on a LLM to assist me in making this change.

I believe this change is required to support https://github.com/espressif/esp-box/issues/110

Thank you for your consideration.