### PR TITLE
Fix LittlevGL link in lvgl_wificonfig_en.md (AEGHB-498)

### DIFF
--- a/examples/hmi/lvgl_wificonfig/lvgl_wificonfig_en.md
+++ b/examples/hmi/lvgl_wificonfig/lvgl_wificonfig_en.md
@@ -9,7 +9,7 @@
 	* 1 x display (2.8 inches, 240x320 pixels, ILI9341 LCD + XPT2046 Touchscreen)
 - Software: 
 	* [esp-iot-solution](https://github.com/espressif/esp-iot-solution)
-	* [LittlevGL GUI](https://littlevgl.com/)
+	* [LittlevGL GUI](https://lvgl.io/)
 
 - Setup: see [README.md](../../../README.md#preparation)
 


### PR DESCRIPTION
The link was incorrect and went to a fake site.

The old link was: https://littlevgl.com/

The new link is: https://lvgl.io/