### PR TITLE
fix(aht20): raw humidity/temperature data conversion (AEGHB-505)

### DIFF
--- a/components/sensors/humiture/aht20/aht20.c
+++ b/components/sensors/humiture/aht20/aht20.c
@@ -115,7 +115,7 @@ esp_err_t aht20_read_temperature_humidity(aht20_dev_handle_t handle,
         raw_data += buf[3];
         raw_data = raw_data >> 4;
         *humidity_raw = raw_data;
-        *humidity = (float)raw_data * 100 / 1048576;
+        *humidity = (float)raw_data * 100 / 1048575;
 
         raw_data = buf[3] & 0x0F;
         raw_data = raw_data << 8;
@@ -123,7 +123,7 @@ esp_err_t aht20_read_temperature_humidity(aht20_dev_handle_t handle,
         raw_data = raw_data << 8;
         raw_data += buf[5];
         *temperature_raw = raw_data;
-        *temperature = (float)raw_data * 200 / 1048576 - 50;
+        *temperature = (float)raw_data * 200 / 1048575 - 50;
         return ESP_OK;
     } else {
         ESP_LOGI(TAG, "data is not ready");


### PR DESCRIPTION
Concerning the conversion of raw_data to humidity/temperature:

humidity = raw_data * 100 / 1048576 gives a max humidity of 99.99990

To get a max humidity of 100:
humidity = raw_data * 100 / 1048575

Similar arguments can be made for the temperature.