### PR TITLE
feat(button): Refactor button press enum values and add BUTTON_PRESS_NORMAL event (AEGHB-527)

### DIFF
--- a/components/button/include/iot_button.h
+++ b/components/button/include/iot_button.h
@@ -22,7 +22,8 @@ typedef void *button_handle_t;
  *
  */
 typedef enum {
-    BUTTON_PRESS_DOWN = 0,
+    BUTTON_PRESS_NORMAL = 0,
+    BUTTON_PRESS_DOWN,
     BUTTON_PRESS_UP,
     BUTTON_PRESS_REPEAT,
     BUTTON_PRESS_REPEAT_DONE,

--- a/components/button/iot_button.c
+++ b/components/button/iot_button.c
@@ -115,6 +115,7 @@ static void button_handler(button_dev_t *btn)
         if (btn->button_level == btn->active_level) {
             btn->event = (uint8_t)BUTTON_PRESS_DOWN;
             CALL_EVENT_CB(BUTTON_PRESS_DOWN);
+            CALL_EVENT_CB(BUTTON_PRESS_NORMAL);
             btn->ticks = 0;
             btn->repeat = 1;
             btn->state = 1;
@@ -127,6 +128,7 @@ static void button_handler(button_dev_t *btn)
         if (btn->button_level != btn->active_level) {
             btn->event = (uint8_t)BUTTON_PRESS_UP;
             CALL_EVENT_CB(BUTTON_PRESS_UP);
+            CALL_EVENT_CB(BUTTON_PRESS_NORMAL);
             btn->ticks = 0;
             btn->state = 2;
 
@@ -153,6 +155,7 @@ static void button_handler(button_dev_t *btn)
         if (btn->button_level == btn->active_level) {
             btn->event = (uint8_t)BUTTON_PRESS_DOWN;
             CALL_EVENT_CB(BUTTON_PRESS_DOWN);
+            CALL_EVENT_CB(BUTTON_PRESS_NORMAL);
             btn->event = (uint8_t)BUTTON_PRESS_REPEAT;
             btn->repeat++;
             CALL_EVENT_CB(BUTTON_PRESS_REPEAT); // repeat hit
@@ -193,6 +196,7 @@ static void button_handler(button_dev_t *btn)
         if (btn->button_level != btn->active_level) {
             btn->event = (uint8_t)BUTTON_PRESS_UP;
             CALL_EVENT_CB(BUTTON_PRESS_UP);
+            CALL_EVENT_CB(BUTTON_PRESS_NORMAL);
             if (btn->ticks < SHORT_TICKS) {
                 btn->ticks = 0;
                 btn->state = 2; //repeat press
@@ -283,6 +287,7 @@ static void button_handler(button_dev_t *btn)
 
             btn->event = (uint8_t)BUTTON_PRESS_UP;
             CALL_EVENT_CB(BUTTON_PRESS_UP);
+            CALL_EVENT_CB(BUTTON_PRESS_NORMAL);
             btn->state = 0; //reset
             btn->long_press_hold_cnt = 0;
         }


### PR DESCRIPTION
- Refactored the enum values for button press in `iot_button.h` to include a new value `BUTTON_PRESS_NORMAL`.
- Added calls to the event callback function for `BUTTON_PRESS_NORMAL` in `iot_button.c` when the button is pressed down or released.

These changes improve the clarity and flexibility of handling different button press events.
