### PR TITLE
Changed C++ reserved keyword 'delete' to 'deleteResponse' (AEGHB-645)

### DIFF
--- a/components/openai/OpenAI.c
+++ b/components/openai/OpenAI.c
@@ -262,7 +262,7 @@ static OpenAI_EmbeddingResponse_t *OpenAI_EmbeddingResponseCreate(const char *pa
     _embeddingResponse->parent.getLen = &OpenAI_EmbeddingResponseGetLen;
     _embeddingResponse->parent.getData = &OpenAI_EmbeddingResponseGetDate;
     _embeddingResponse->parent.getError = &OpenAI_EmbeddingResponseGetError;
-    _embeddingResponse->parent.delete = &OpenAI_EmbeddingResponseDelete;
+    _embeddingResponse->parent.deleteResponse = &OpenAI_EmbeddingResponseDelete;
     cJSON_Delete(json);
     return &_embeddingResponse->parent;
 end:
@@ -371,7 +371,7 @@ static OpenAI_ModerationResponse_t *OpenAI_ModerationResponseCreate(const char *
     _moderationResponse->parent.getLen = &OpenAI_ModerationResponseGetLen;
     _moderationResponse->parent.getData = &OpenAI_ModerationResponseGetDate;
     _moderationResponse->parent.getError = &OpenAI_ModerationResponseGetError;
-    _moderationResponse->parent.delete = &OpenAI_ModerationResponseDelete;
+    _moderationResponse->parent.deleteResponse = &OpenAI_ModerationResponseDelete;
     return &_moderationResponse->parent;
 end:
     cJSON_Delete(json);
@@ -503,7 +503,7 @@ OpenAI_ImageResponse_t *OpenAI_ImageResponseCreate(const char *payload)
     _imageResponse->parent.getLen = &OpenAI_ImageResponseGetLen;
     _imageResponse->parent.getData = &OpenAI_ImageResponseGetDate;
     _imageResponse->parent.getError = &OpenAI_ImageResponseGetError;
-    _imageResponse->parent.delete = &OpenAI_ImageResponseDelete;
+    _imageResponse->parent.deleteResponse = &OpenAI_ImageResponseDelete;
     return &_imageResponse->parent;
 end:
     cJSON_Delete(json);
@@ -657,7 +657,7 @@ static OpenAI_StringResponse_t *OpenAI_StringResponseCreate(char *payload)
     _stringResponse->parent.getLen = &OpenAI_StringResponseGetLen;
     _stringResponse->parent.getData = &OpenAI_StringResponseGetDate;
     _stringResponse->parent.getError = &OpenAI_StringResponseGetError;
-    _stringResponse->parent.delete = &OpenAI_StringResponseDelete;
+    _stringResponse->parent.deleteResponse = &OpenAI_StringResponseDelete;
     return &_stringResponse->parent;
 end:
     cJSON_Delete(json);
@@ -1903,7 +1903,7 @@ static OpenAI_SpeechResponse_t *OpenAI_SpeechResponseCreate(char *payload, size_
 
     _audioSpeech->parent.getLen = &OpenAI_SpeechBufferGetLen;
     _audioSpeech->parent.getData = &OpenAI_SpeechGetDate;
-    _audioSpeech->parent.delete = &OpenAI_SpeechResponseDelete;
+    _audioSpeech->parent.deleteResponse = &OpenAI_SpeechResponseDelete;
     return &_audioSpeech->parent;
 end:
     free(payload);

--- a/components/openai/include/OpenAI.h
+++ b/components/openai/include/OpenAI.h
@@ -107,7 +107,7 @@ typedef struct OpenAI_EmbeddingResponse {
      *
      * @param embeddingData[in] the point of OpenAI_EmbeddingResponse
      */
-    void (*delete)(struct OpenAI_EmbeddingResponse *embeddingData);
+    void (*deleteResponse)(struct OpenAI_EmbeddingResponse *embeddingData);
 } OpenAI_EmbeddingResponse_t;
 
 /**
@@ -146,7 +146,7 @@ typedef struct OpenAI_ModerationResponse {
      *
      * @param moderationResponse[in] the point of } OpenAI_ModerationResponse_t
      */
-    void (*delete)(struct OpenAI_ModerationResponse *moderationResponse);
+    void (*deleteResponse)(struct OpenAI_ModerationResponse *moderationResponse);
 } OpenAI_ModerationResponse_t;
 
 /**
@@ -185,7 +185,7 @@ typedef struct OpenAI_ImageResponse {
      *
      * @param imageResponse[in] the point of } OpenAI_ImageResponse_t
      */
-    void (*delete)(struct OpenAI_ImageResponse *imageResponse);
+    void (*deleteResponse)(struct OpenAI_ImageResponse *imageResponse);
 } OpenAI_ImageResponse_t;
 
 /**
@@ -230,7 +230,7 @@ typedef struct OpenAI_StringResponse {
      *
      * @param stringResponse[in] the point of OpenAI_StringResponse_t
      */
-    void (*delete)(struct OpenAI_StringResponse *stringResponse);
+    void (*deleteResponse)(struct OpenAI_StringResponse *stringResponse);
 } OpenAI_StringResponse_t;
 
 /**
@@ -259,7 +259,7 @@ typedef struct OpenAI_SpeechResponse {
      *
      * @param SpeechResponse[in] the point of OpenAI_SpeechResponse_t
      */
-    void (*delete)(struct OpenAI_SpeechResponse *SpeechResponse);
+    void (*deleteResponse)(struct OpenAI_SpeechResponse *SpeechResponse);
 
 } OpenAI_SpeechResponse_t;
 


### PR DESCRIPTION
I created a empty PIO project, preformed clean build, and added OpenAI component.

Because I am using C++, the keyword 'delete' is reserved and needed to be changed to a non-reserved keyword.