### PR TITLE
fix: ADC button tied to GND ignored (AEGHB-691)

### DIFF
--- a/components/button/CHANGELOG.md
+++ b/components/button/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## v3.2.1 - 2024-6-17
+
+### bugfix
+
+- Fixed ignored ADC button tied to GND.
 
 ## v3.2.0 - 2023-11-13
 

--- a/components/button/button_adc.c
+++ b/components/button/button_adc.c
@@ -305,7 +305,7 @@ uint8_t button_adc_get_key_level(void *button_index)
     }
 
     if (vol <= g_button.ch[ch_index].btns[index].max &&
-            vol > g_button.ch[ch_index].btns[index].min) {
+            vol >= g_button.ch[ch_index].btns[index].min) {
         return 1;
     }
     return 0;

--- a/components/button/idf_component.yml
+++ b/components/button/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.2.0"
+version: "3.2.1"
 description: GPIO and ADC button driver
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/button
 repository: https://github.com/espressif/esp-iot-solution.git


### PR DESCRIPTION
**Bug:** if there is an ADC button in the group which is tied to GND the read value is ignored and callbacks do not work. SW2 on attached screenshot cannot be enabled. 
**Reason:** `adc_button_config.min = 0` is not included in the condition.
**Fix:** include `adc_button_config.min = 0` in `button_adc_get_key_level` method.
<img width="721" alt="Screenshot 2024-06-17 at 01 15 18" src="https://github.com/espressif/esp-iot-solution/assets/6042130/a209c56a-8778-49fc-baf5-7080303e344e">
