### PR TITLE
docs: fix typo in USB overview (AEGHB-762)

### DIFF
--- a/docs/en/usb/usb_overview/usb_overview.rst
+++ b/docs/en/usb/usb_overview/usb_overview.rst
@@ -85,7 +85,7 @@ ESP32-S/C Series USB Peripheral Support
      - USB OTG High-Speed
      - USB OTG Full-Speed
      - USB-Serial-JTAG
-     - Fulls-Peed PHY
+     - Full-Speed PHY
      - High-Speed PHY
    * - **ESP32-P4**
      - √

--- a/docs/zh_CN/usb/usb_overview/usb_overview.rst
+++ b/docs/zh_CN/usb/usb_overview/usb_overview.rst
@@ -85,7 +85,7 @@ ESP32-S/C 系列 USB 外设支持情况
      - USB OTG High-speed
      - USB OTG Full-speed
      - USB-Serial-JTAG
-     - Fulls-peed PHY
+     - Full-speed PHY
      - High-speed PHY
    * - **ESP32-P4**
      - √


### PR DESCRIPTION
Fixes a typo of "Full-Speed" in the USB docs.