### PR TITLE
Fix the error caused by recursion in read_content function

### DIFF
--- a/examples/hmi/mp3_example/main/app_main.c
+++ b/examples/hmi/mp3_example/main/app_main.c
@@ -375,11 +375,12 @@ static void sdmmc_init()
     sdmmc_card_print_info(stdout, card);
 }
 
-static void read_content(const char *path, uint8_t *filecount)
+static int read_content(const char *path, uint8_t *filecount)
 {
-    char nextpath[100];
+    int ret = 0;
+    char nextpath[300];
     struct dirent *de;
-    *filecount = 0;
+    // *filecount = 0;
     DIR *dir = opendir(path);
     while (1) {
         de = readdir(dir);
@@ -388,17 +389,23 @@ static void read_content(const char *path, uint8_t *filecount)
         } else if (de->d_type == DT_REG) {
             if (strstr(de->d_name, ".mp3") || strstr(de->d_name, ".MP3")) {
                 sprintf(directory[*filecount], "%s/%s", path, de->d_name);
-                printf("%s\n", directory[*filecount]);
-                if ((*filecount)++ >= MAX_PLAY_FILE_NUM) {
+                printf("filecount = %d :%s\n", (*filecount) , directory[*filecount]);
+                if (++(*filecount) >= MAX_PLAY_FILE_NUM) {
+                    ESP_LOGE(TAG,"break %d",(*filecount));
+                    ret = -1;
                     break;
                 }
             }
         } else if (de->d_type == DT_DIR) {
             sprintf(nextpath, "%s/%s", path, de->d_name);
-            read_content(nextpath, filecount);
+            ret = read_content(nextpath, filecount);
+            if(ret == -1){
+                break;
+            }
         }
     }
     closedir(dir);
+    return ret;
 }
 
 #if USE_ADF_TO_PLAY


### PR DESCRIPTION
read_content函数的“if ((*filecount)++ >= MAX_PLAY_FILE_NUM) ”语句导致directory越界，同时有个递归错误。
The "if ((*filecount)++ >= MAX_PLAY_FILE_NUM)" statement in the read_content function causes directory to be out of bounds and there is a recursive error.