### PR TITLE
Fix cmake file for gprof (AEGHB-792)

### DIFF
--- a/components/gprof/CMakeLists.txt
+++ b/components/gprof/CMakeLists.txt
@@ -12,4 +12,6 @@ idf_component_register(SRCS ${srcs}
                        REQUIRES "spi_flash" "app_update")
 
 include(package_manager)
-cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})
+if(CONFIG_GPROF_ENABLE)
+    cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})
+endif()


### PR DESCRIPTION
In case CONFIG_GPROF_ENABLE is not configured, this error occured:
"target_compile_options may only set INTERFACE properties on INTERFACE"