### PR TITLE
feat: components support software bill of materials (AEGHB-868)

### DIFF
--- a/components/audio/pwm_audio/idf_component.yml
+++ b/components/audio/pwm_audio/idf_component.yml
@@ -7,3 +7,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">=4.3"
   espressif/cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/avi_player/idf_component.yml
+++ b/components/avi_player/idf_component.yml
@@ -7,3 +7,6 @@ repository: https://github.com/espressif/esp-iot-solution.git
 dependencies:
   idf: ">=4.4"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/bluetooth/ble_conn_mgr/idf_component.yml
+++ b/components/bluetooth/ble_conn_mgr/idf_component.yml
@@ -6,3 +6,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../examples/bluetooth/ble_conn_mgr
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/bluetooth/ble_hci/idf_component.yml
+++ b/components/bluetooth/ble_hci/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../examples/bluetooth/ble_hci
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/bluetooth/ble_profiles/esp/ble_ota/idf_component.yml
+++ b/components/bluetooth/ble_profiles/esp/ble_ota/idf_component.yml
@@ -14,3 +14,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../../examples/bluetooth/ble_ota
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/bluetooth/ble_profiles/std/ble_anp/idf_component.yml
+++ b/components/bluetooth/ble_profiles/std/ble_anp/idf_component.yml
@@ -4,3 +4,6 @@ url: https://github.com/espressif/esp-iot-solution/tree/master/components/blueto
 issues: https://github.com/espressif/esp-iot-solution/issues
 examples:
   - path: ../../../../../examples/bluetooth/ble_profiles
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/bluetooth/ble_profiles/std/ble_hrp/idf_component.yml
+++ b/components/bluetooth/ble_profiles/std/ble_hrp/idf_component.yml
@@ -4,3 +4,6 @@ url: https://github.com/espressif/esp-iot-solution/tree/master/components/blueto
 issues: https://github.com/espressif/esp-iot-solution/issues
 examples:
   - path: ../../../../../examples/bluetooth/ble_profiles
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/bluetooth/ble_profiles/std/ble_htp/idf_component.yml
+++ b/components/bluetooth/ble_profiles/std/ble_htp/idf_component.yml
@@ -4,3 +4,6 @@ url: https://github.com/espressif/esp-iot-solution/tree/master/components/blueto
 issues: https://github.com/espressif/esp-iot-solution/issues
 examples:
   - path: ../../../../../examples/bluetooth/ble_profiles
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/bluetooth/ble_services/idf_component.yml
+++ b/components/bluetooth/ble_services/idf_component.yml
@@ -4,3 +4,6 @@ url: https://github.com/espressif/esp-iot-solution/tree/master/components/blueto
 issues: https://github.com/espressif/esp-iot-solution/issues
 examples:
   - path: ../../../examples/bluetooth/ble_services
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/bootloader_support_plus/idf_component.yml
+++ b/components/bootloader_support_plus/idf_component.yml
@@ -14,3 +14,6 @@ dependencies:
   xz: "1.*"
 examples:
   - path: ../../examples/ota/simple_ota_example
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/button/idf_component.yml
+++ b/components/button/idf_component.yml
@@ -9,3 +9,6 @@ examples:
 dependencies:
   idf: ">=4.0"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_axs15231b/idf_component.yml
+++ b/components/display/lcd/esp_lcd_axs15231b/idf_component.yml
@@ -8,3 +8,6 @@ dependencies:
 description: ESP LCD & Touch AXS15231B
 url: https://github.com/espressif/esp-bsp/tree/master/components/lcd/esp_lcd_axs15231b
 version: 1.0.0
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_ek79007/idf_component.yml
+++ b/components/display/lcd/esp_lcd_ek79007/idf_component.yml
@@ -8,3 +8,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">=5.3"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_gc9b71/idf_component.yml
+++ b/components/display/lcd/esp_lcd_gc9b71/idf_component.yml
@@ -8,3 +8,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../examples/display/lcd/qspi_with_ram
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_hx8399/idf_component.yml
+++ b/components/display/lcd/esp_lcd_hx8399/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   idf:
     version: '>=5.3'
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_jd9165/idf_component.yml
+++ b/components/display/lcd/esp_lcd_jd9165/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   idf:
     version: '>=5.3'
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_jd9365/idf_component.yml
+++ b/components/display/lcd/esp_lcd_jd9365/idf_component.yml
@@ -8,3 +8,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">=5.3"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_nv3022b/idf_component.yml
+++ b/components/display/lcd/esp_lcd_nv3022b/idf_component.yml
@@ -6,3 +6,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">=4.4"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_panel_io_additions/idf_component.yml
+++ b/components/display/lcd/esp_lcd_panel_io_additions/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   esp_io_expander:
     version: "^1"
     public: true
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_sh8601/idf_component.yml
+++ b/components/display/lcd/esp_lcd_sh8601/idf_component.yml
@@ -8,3 +8,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../examples/display/lcd/qspi_with_ram
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_spd2010/idf_component.yml
+++ b/components/display/lcd/esp_lcd_spd2010/idf_component.yml
@@ -8,3 +8,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../examples/display/lcd/qspi_with_ram
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_st7701/idf_component.yml
+++ b/components/display/lcd/esp_lcd_st7701/idf_component.yml
@@ -11,3 +11,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../examples/display/lcd/rgb_avoid_tearing
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_st7703/idf_component.yml
+++ b/components/display/lcd/esp_lcd_st7703/idf_component.yml
@@ -8,3 +8,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">=5.3"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_st77903_qspi/idf_component.yml
+++ b/components/display/lcd/esp_lcd_st77903_qspi/idf_component.yml
@@ -8,3 +8,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../examples/display/lcd/qspi_without_ram
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_st77903_rgb/idf_component.yml
+++ b/components/display/lcd/esp_lcd_st77903_rgb/idf_component.yml
@@ -10,3 +10,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../examples/display/lcd/rgb_lcd_8bit
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_st77916/idf_component.yml
+++ b/components/display/lcd/esp_lcd_st77916/idf_component.yml
@@ -6,3 +6,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">5.0.4,!=5.1.1"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_st77922/idf_component.yml
+++ b/components/display/lcd/esp_lcd_st77922/idf_component.yml
@@ -6,3 +6,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">5.0.4,!=5.1.1"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd/esp_lcd_usb_display/idf_component.yml
+++ b/components/display/lcd/esp_lcd_usb_display/idf_component.yml
@@ -10,3 +10,6 @@ dependencies:
   espressif/usb_device_uvc:
     version: "1.1.*"
     override_path: "../../../../components/usb/usb_device_uvc"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd_touch/esp_lcd_touch_spd2010/idf_component.yml
+++ b/components/display/lcd_touch/esp_lcd_touch_spd2010/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   esp_lcd_touch:
     version: "^1"
     public: true
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/lcd_touch/esp_lcd_touch_st7123/idf_component.yml
+++ b/components/display/lcd_touch/esp_lcd_touch_st7123/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   esp_lcd_touch:
     version: "^1"
     public: true
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/tools/esp_lv_decoder/idf_component.yml
+++ b/components/display/tools/esp_lv_decoder/idf_component.yml
@@ -24,3 +24,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../examples/hmi/perf_benchmark
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/tools/esp_lv_fs/idf_component.yml
+++ b/components/display/tools/esp_lv_fs/idf_component.yml
@@ -22,3 +22,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../../examples/hmi/perf_benchmark
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/display/tools/esp_mmap_assets/idf_component.yml
+++ b/components/display/tools/esp_mmap_assets/idf_component.yml
@@ -20,3 +20,6 @@ url: https://github.com/espressif/esp-iot-solution/tree/master/components/displa
 documentation: https://docs.espressif.com/projects/esp-iot-solution/en/latest/display/tools/esp_mmap_assets.html
 examples:
   - path: ../../../../examples/hmi/perf_benchmark
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/elf_loader/idf_component.yml
+++ b/components/elf_loader/idf_component.yml
@@ -7,3 +7,6 @@ dependencies:
 examples:
   - path:  ../../examples/elf_loader/build_elf_file_example
   - path:  ../../examples/elf_loader/elf_loader_example
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/extended_vfs/idf_component.yml
+++ b/components/extended_vfs/idf_component.yml
@@ -11,3 +11,6 @@ examples:
   - path:  ../../examples/extended_vfs/ledc/ledc_simple
   - path:  ../../examples/extended_vfs/spi/spi_master_simple
   - path:  ../../examples/extended_vfs/spi/spi_slave_simple
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/gprof/idf_component.yml
+++ b/components/gprof/idf_component.yml
@@ -6,3 +6,6 @@ dependencies:
   espressif/cmake_utilities: "0.*"
 examples:
   - path:  ../../examples/gprof/gprof_simple
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/i2c_bus/idf_component.yml
+++ b/components/i2c_bus/idf_component.yml
@@ -8,3 +8,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">=4.0"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/ir/ir_learn/idf_component.yml
+++ b/components/ir/ir_learn/idf_component.yml
@@ -14,3 +14,6 @@ documentation: https://docs.espressif.com/projects/esp-iot-solution/en/latest/ir
 dependencies:
   idf: ">=5.0"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/keyboard_button/idf_component.yml
+++ b/components/keyboard_button/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../examples/keyboard
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/knob/idf_component.yml
+++ b/components/knob/idf_component.yml
@@ -10,3 +10,6 @@ dependencies:
 examples:
   - path: ../../examples/usb/device/usb_surface_dial
   - path: ../../examples/get-started/knob_power_save
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/led/led_indicator/idf_component.yml
+++ b/components/led/led_indicator/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../examples/indicator
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/led/lightbulb_driver/idf_component.yml
+++ b/components/led/lightbulb_driver/idf_component.yml
@@ -6,3 +6,6 @@ dependencies:
   espressif/cmake_utilities: "0.*"
 examples:
   - path:  ../../../examples/lighting/lightbulb
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/motor/drv10987/idf_component.yml
+++ b/components/motor/drv10987/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   i2c_bus:
     version: "*"
     override_path: "../../i2c_bus"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/motor/esp_sensorless_bldc_control/idf_component.yml
+++ b/components/motor/esp_sensorless_bldc_control/idf_component.yml
@@ -16,3 +16,6 @@ dependencies:
     version: '>=5.0'
 examples:
   - path: ../../../examples/motor/bldc_fan_rainmaker
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/motor/esp_simplefoc/idf_component.yml
+++ b/components/motor/esp_simplefoc/idf_component.yml
@@ -21,3 +21,6 @@ examples:
   - path: ../../../examples/motor/foc_openloop_control
   - path: ../../../examples/motor/foc_velocity_control
   - path: ../../../examples/motor/foc_knob_example
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/openai/idf_component.yml
+++ b/components/openai/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   idf:
     version: ">=4.4.0"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/sensors/humiture/aht20/idf_component.yml
+++ b/components/sensors/humiture/aht20/idf_component.yml
@@ -4,3 +4,6 @@ url: https://github.com/espressif/esp-iot-solution/tree/master/components/sensor
 dependencies:
   idf: '>=4.3'
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/sensors/ntc_driver/idf_component.yml
+++ b/components/sensors/ntc_driver/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../examples/sensors/ntc_temperature_sensor
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/sensors/power_monitor/ina236/idf_component.yml
+++ b/components/sensors/power_monitor/ina236/idf_component.yml
@@ -8,3 +8,6 @@ dependencies:
   i2c_bus:
     version: "*"
     override_path: "../../../i2c_bus"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/sensors/radar/at581x/idf_component.yml
+++ b/components/sensors/radar/at581x/idf_component.yml
@@ -10,3 +10,6 @@ url: https://github.com/espressif/esp-iot-solution/tree/master/components/sensor
 dependencies:
   idf: '>=4.3'
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/spi_bus/idf_component.yml
+++ b/components/spi_bus/idf_component.yml
@@ -7,3 +7,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">=4.0"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/touch/touch_proximity_sensor/idf_component.yml
+++ b/components/touch/touch_proximity_sensor/idf_component.yml
@@ -10,3 +10,6 @@ dependencies:
   cmake_utilities: "0.*"
 examples:
   - path: ../../../examples/touch/touch_proximity
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/usb/esp_msc_ota/idf_component.yml
+++ b/components/usb/esp_msc_ota/idf_component.yml
@@ -15,3 +15,6 @@ dependencies:
   espressif/usb_host_msc: "^1.1.2"
 examples:
   - path: ../../../examples/usb/host/usb_msc_ota
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/usb/esp_tinyuf2/idf_component.yml
+++ b/components/usb/esp_tinyuf2/idf_component.yml
@@ -19,3 +19,6 @@ dependencies:
 examples:
   - path: ../../../examples/usb/device/usb_uf2_ota
   - path: ../../../examples/usb/device/usb_uf2_nvs
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/usb/iot_usbh/idf_component.yml
+++ b/components/usb/iot_usbh/idf_component.yml
@@ -9,3 +9,6 @@ issues: https://github.com/espressif/esp-iot-solution/issues
 dependencies:
   idf: ">=4.4.1"
   cmake_utilities: "0.*"
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/usb/iot_usbh_cdc/idf_component.yml
+++ b/components/usb/iot_usbh_cdc/idf_component.yml
@@ -16,3 +16,6 @@ dependencies:
     override_path: "../iot_usbh"
 examples:
   - path: ../../../examples/usb/host/usb_cdc_basic
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/usb/iot_usbh_modem/idf_component.yml
+++ b/components/usb/iot_usbh_modem/idf_component.yml
@@ -14,3 +14,6 @@ dependencies:
     override_path: "../iot_usbh_cdc"
 examples:
   - path: ../../../examples/usb/host/usb_cdc_4g_module
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/usb/usb_device_uac/idf_component.yml
+++ b/components/usb/usb_device_uac/idf_component.yml
@@ -17,3 +17,6 @@ dependencies:
   cmake_utilities: "*"
 examples:
   - path: ../../../examples/usb/device/usb_uac
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/usb/usb_device_uvc/idf_component.yml
+++ b/components/usb/usb_device_uvc/idf_component.yml
@@ -18,3 +18,6 @@ dependencies:
 examples:
   - path: ../../../examples/usb/device/usb_webcam
   - path: ../../../examples/usb/device/usb_dual_uvc_device
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/usb/usb_stream/idf_component.yml
+++ b/components/usb/usb_stream/idf_component.yml
@@ -13,3 +13,6 @@ dependencies:
 examples:
   - path: ../../../examples/usb/host/usb_camera_mic_spk
   - path: ../../../examples/usb/host/usb_camera_lcd_display
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/utilities/xz/idf_component.yml
+++ b/components/utilities/xz/idf_component.yml
@@ -5,3 +5,6 @@ dependencies:
   idf: ">=4.1"
 examples:
   - path: ../../../examples/utilities/xz_decompress_file
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'

--- a/components/zero_detection/idf_component.yml
+++ b/components/zero_detection/idf_component.yml
@@ -9,3 +9,6 @@ dependencies:
   espressif/cmake_utilities: "0.*"
 examples:
   - path: ../../examples/zero_cross_detection
+sbom:
+  supplier: 'Organization: Espressif Systems (Shanghai) CO LTD'
+  originator: 'Organization: Espressif Systems (Shanghai) CO LTD'


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->


<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

esp iot solution components support software bill of materials



## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

N/A

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Enter any example directory and execute the following command:


```shell
➜  lightbulb git:(feat/support_esp_idf_sbom) idf.py build
➜  lightbulb git:(feat/support_esp_idf_sbom) esp-idf-sbom create -o lightbulb.spdx build/project_description.json
➜  lightbulb git:(feat/support_esp_idf_sbom) ✗ esp-idf-sbom check lightbulb.spdx        
```

```shell
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 44/44 0:00:23  
                                                         Report summary                                                          
┌───────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────┐
│ Date:                             │ 2024-11-07T06:35:42Z                                                                      │
│ Project name:                     │ project-lightbulb_example                                                                 │
│ Project version:                  │ f3481c35                                                                                  │
│ Vulnerability database:           │ NATIONAL VULNERABILITY DATABASE REST API (https://nvd.nist.gov)                           │
│ Generated by tool:                │ esp-idf-sbom (0.19.1)                                                                     │
│ Generated with command:           │ /home/yanke/.espressif/python_env/idf5.5_py3.10_env/bin/esp-idf-sbom check lightbulb.spdx │
│ Number of scanned packages:       │ 44                                                                                        │
├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
│ CRITICAL CVEs found:              │                                                                                           │
│ Packages affect by CRITICAL CVEs: │                                                                                           │
│ Number of CRITICAL CVEs:          │ 0                                                                                         │
├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
│ HIGH CVEs found:                  │                                                                                           │
│ Packages affect by HIGH CVEs:     │                                                                                           │
│ Number of HIGH CVEs:              │ 0                                                                                         │
├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
│ MEDIUM CVEs found:                │                                                                                           │
│ Packages affect by MEDIUM CVEs:   │                                                                                           │
│ Number of MEDIUM CVEs:            │ 0                                                                                         │
├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
│ LOW CVEs found:                   │                                                                                           │
│ Packages affect by LOW CVEs:      │                                                                                           │
│ Number of LOW CVEs:               │ 0                                                                                         │
├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
│ UNKNOWN CVEs found:               │                                                                                           │
│ Packages affect by UNKNOWN CVEs:  │                                                                                           │
│ Number of UNKNOWN CVEs:           │ 0                                                                                         │
├───────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
│ All CVEs found:                   │                                                                                           │
│ All packages affect by CVEs:      │                                                                                           │
│ Total number of CVEs:             │ 0                                                                                         │
└───────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────┘


                                                                                     Packages with Excluded Vulnerabilities                                                                                      
┏━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Package  ┃ Version ┃     CVE ID     ┃ Base Score ┃ Base Severity ┃                                                                Information                                                                 ┃
┡━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│          │         │                │            │               │  CVSS    3.1                                                                                                                               │
│          │         │                │            │               │  Vec.    CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H                                                                                      │
│          │         │                │            │               │  CPE     cpe:2.3:a:newlib_project:newlib:4.3.0:*:*:*:*:*:*:*                                                                               │
│  newlib  │  4.3.0  │ CVE-2024-30949 │    9.8     │   CRITICAL    │  Link    https://nvd.nist.gov/vuln/detail/CVE-2024-30949                                                                                   │
│          │         │                │            │               │  Desc.   An issue in newlib v.4.3.0 allows an attacker to execute arbitrary code via the time unit scaling in the _gettimeofday function.  │
│          │         │                │            │               │  Reason  A vulnerability was discovered in the gettimeofday system call implementation within the RISC-V libgloss component of Newlib.     │
│          │         │                │            │               │          ESP-IDF does not link against libgloss for RISC-V, hence the issue is not directly applicable. Still, the relevant fix has been   │
│          │         │                │            │               │          patched through https://github.com/espressif/newlib-esp32/commit/047ba47013c2656a1e7838dc86cbc75aeeaa67a7                         │
├──────────┼─────────┼────────────────┼────────────┼───────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│          │         │                │            │               │  CVSS    3.1                                                                                                                               │
│          │         │                │            │               │  Vec.    CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H                                                                                      │
│          │         │                │            │               │  CPE     cpe:2.3:o:amazon:freertos:10.5.1:*:*:*:*:*:*:*                                                                                    │
│          │         │                │            │               │  Link    https://nvd.nist.gov/vuln/detail/CVE-2024-28115                                                                                   │
│ freertos │ 10.5.1  │ CVE-2024-28115 │    7.8     │     HIGH      │  Desc.   FreeRTOS is a real-time operating system for microcontrollers. FreeRTOS Kernel versions through 10.6.1 do not sufficiently        │
│          │         │                │            │               │          protect against local privilege escalation via Return Oriented Programming techniques should a vulnerability exist that allows    │
│          │         │                │            │               │          code injection and execution. These issues affect ARMv7-M MPU ports, and ARMv8-M ports with Memory Protected Unit (MPU) support   │
│          │         │                │            │               │          enabled (i.e. `configENABLE_MPU` set to 1). These issues are fixed in version 10.6.2 with a new MPU wrapper.                      │
│          │         │                │            │               │  Reason  Affects only ARMv7-M MPU ports, and ARMv8-M ports with Memory Protected Unit (MPU) support enabled                                │
└──────────┴─────────┴────────────────┴────────────┴───────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
                                                                         Already assessed vulnerabilities that do not apply to packages.                                                                         


                                Packages with No Identified Vulnerabilities                                 
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃          Package          ┃ Version  ┃                                CPE                                ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ project-lightbulb_example │ f3481c35 │ cpe:2.3:a:espressif:esp-idf:5.5-dev-183-g6fdd380812:*:*:*:*:*:*:* │
└───────────────────────────┴──────────┴───────────────────────────────────────────────────────────────────┘
                        Packages checked against NVD with no vulnerabilities found.                         


       Packages without CPE and Keyword Information        
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃           Package            ┃         Version          ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│   toolchain-xtensa-esp-elf   │   esp-14.2.0_20240906    │
├──────────────────────────────┼──────────────────────────┤
│      component-console       │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│        component-cxx         │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│     component-esp_common     │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│      component-esp_phy       │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│        component-log         │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│        component-main        │         f3481c35         │
├──────────────────────────────┼──────────────────────────┤
│  component-nvs_sec_provider  │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│       component-xtensa       │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│          argtable3           │          3.2.2           │
├──────────────────────────────┼──────────────────────────┤
│  component-esp_driver_uart   │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│  component-esp_vfs_console   │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│        component-vfs         │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│      component-pthread       │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│     component-esp_system     │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│    submodule-esp_phy-lib     │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│       component-driver       │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│       component-efuse        │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│     component-nvs_flash      │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│     component-esp_timer      │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│        component-hal         │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│        component-soc         │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│   component-esp_hw_support   │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│  component-lightbulb_driver  │          1.3.2           │
├──────────────────────────────┼──────────────────────────┤
│ component-bootloader_support │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│   component-esp_partition    │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│  component-esp_driver_gpio   │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│    component-esp_ringbuf     │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│       component-esp_pm       │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│     component-spi_flash      │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│       component-esp_mm       │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│ component-esp_driver_gptimer │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│  component-esp_driver_ledc   │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│   component-esp_driver_spi   │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│      component-freertos      │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│   component-esp_app_format   │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│      component-esp_rom       │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│    component-esp_security    │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│        component-heap        │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│     component-app_update     │ v5.5-dev-183-g6fdd380812 │
├──────────────────────────────┼──────────────────────────┤
│     submodule-heap-tlsf      │ v5.5-dev-183-g6fdd380812 │
└──────────────────────────────┴──────────────────────────┘
Packages were not checked against the NVD due to the absence of CPE or keywords.
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
