### PR TITLE
fix(lcd): Fixed the initialization description errors for multiple LCD

### DIFF
--- a/components/display/lcd/esp_lcd_axs15231b/README.md
+++ b/components/display/lcd/esp_lcd_axs15231b/README.md
@@ -25,10 +25,10 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize SPI bus");
-    const spi_bus_config_t bus_config = AXS15231B_PANEL_BUS_SPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+    const spi_bus_config_t buscfg = AXS15231B_PANEL_BUS_SPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
                                                                     EXAMPLE_PIN_NUM_LCD_DATA0,
                                                                     EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
-    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &bus_config, SPI_DMA_CH_AUTO));
+    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
     ESP_LOGI(TAG, "Install panel IO");
     esp_lcd_panel_io_handle_t io_handle = NULL;
@@ -74,12 +74,12 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize QSPI bus");
-    const esp_lcd_panel_io_spi_config_t io_config = AXS15231B_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA0,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA1,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA2,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA3,
-                                                                                 EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
+    const spi_bus_config_t buscfg = AXS15231B_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+                                                                        EXAMPLE_PIN_NUM_LCD_DATA0,
+                                                                        EXAMPLE_PIN_NUM_LCD_DATA1,
+                                                                        EXAMPLE_PIN_NUM_LCD_DATA2,
+                                                                        EXAMPLE_PIN_NUM_LCD_DATA3,
+                                                                        EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
     ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
     ESP_LOGI(TAG, "Install panel IO");
@@ -102,7 +102,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install AXS15231B panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    axs15231b_vendor_config_t vendor_config = {
+    const axs15231b_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(axs15231b_lcd_init_cmd_t),
         .flags = {

--- a/components/display/lcd/esp_lcd_gc9b71/README.md
+++ b/components/display/lcd/esp_lcd_gc9b71/README.md
@@ -52,7 +52,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install GC9B71 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    gc9b71_vendor_config_t vendor_config = {
+    const gc9b71_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(gc9b71_lcd_init_cmd_t),
         .flags = {
@@ -75,12 +75,12 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize QSPI bus");
-    const esp_lcd_panel_io_spi_config_t io_config = GC9B71_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA0,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA1,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA2,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA3,
-                                                                                 EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
+    const spi_bus_config_t buscfg = GC9B71_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA0,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA1,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA2,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA3,
+                                                                    EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
     ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
     ESP_LOGI(TAG, "Install panel IO");
@@ -103,7 +103,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install GC9B71 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    gc9b71_vendor_config_t vendor_config = {
+    const gc9b71_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Only useful when `use_external_init_cmds` is set to 1
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(gc9b71_lcd_init_cmd_t),
         .flags = {

--- a/components/display/lcd/esp_lcd_sh8601/README.md
+++ b/components/display/lcd/esp_lcd_sh8601/README.md
@@ -24,13 +24,13 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize SPI bus");
-    const esp_lcd_panel_io_spi_config_t io_config = SH8601_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA0,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA1,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA2,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA3,
-                                                                                 EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
-    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &bus_config, SPI_DMA_CH_AUTO));
+    const spi_bus_config_t buscfg = SH8601_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA0,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA1,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA2,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA3,
+                                                                    EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
+    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
     ESP_LOGI(TAG, "Install panel IO");
     esp_lcd_panel_io_handle_t io_handle = NULL;
@@ -53,7 +53,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install SH8601 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    sh8601_vendor_config_t vendor_config = {
+    const sh8601_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(sh8601_lcd_init_cmd_t),
         .flags = {
@@ -76,7 +76,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize QSPI bus");
-    const esp_lcd_panel_io_spi_config_t io_config = SH8601_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+    const spi_bus_config_t buscfg = SH8601_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA0,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA1,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA2,
@@ -104,7 +104,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install SH8601 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    sh8601_vendor_config_t vendor_config = {
+    const sh8601_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(sh8601_lcd_init_cmd_t),
         .flags = {

--- a/components/display/lcd/esp_lcd_spd2010/README.md
+++ b/components/display/lcd/esp_lcd_spd2010/README.md
@@ -26,10 +26,10 @@ For more information on LCD, please refer to the [LCD documentation](https://doc
 
 ```c
     ESP_LOGI(TAG, "Initialize SPI bus");
-    const spi_bus_config_t bus_config = SPD2010_PANEL_BUS_SPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+    const spi_bus_config_t buscfg = SPD2010_PANEL_BUS_SPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
                                                                     EXAMPLE_PIN_NUM_LCD_DATA0,
                                                                     EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
-    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &bus_config, SPI_DMA_CH_AUTO));
+    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
     ESP_LOGI(TAG, "Install panel IO");
     esp_lcd_panel_io_handle_t io_handle = NULL;
@@ -74,7 +74,7 @@ For more information on LCD, please refer to the [LCD documentation](https://doc
 
 ```c
     ESP_LOGI(TAG, "Initialize QSPI bus");
-    const esp_lcd_panel_io_spi_config_t io_config = SPD2010_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+    const spi_bus_config_t buscfg = SPD2010_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA0,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA1,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA2,
@@ -102,7 +102,7 @@ For more information on LCD, please refer to the [LCD documentation](https://doc
 
     ESP_LOGI(TAG, "Install SPD2010 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    spd2010_vendor_config_t vendor_config = {
+    const spd2010_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(spd2010_lcd_init_cmd_t),
         .flags = {

--- a/components/display/lcd/esp_lcd_st77916/README.md
+++ b/components/display/lcd/esp_lcd_st77916/README.md
@@ -26,8 +26,8 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize SPI bus");
-    const spi_bus_config_t bus_config = ST77916_PANEL_BUS_SPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK, EXAMPLE_PIN_NUM_LCD_DATA0, EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
-    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &bus_config, SPI_DMA_CH_AUTO));
+    const spi_bus_config_t buscfg = ST77916_PANEL_BUS_SPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK, EXAMPLE_PIN_NUM_LCD_DATA0, EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
+    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
     ESP_LOGI(TAG, "Install panel IO");
     esp_lcd_panel_io_handle_t io_handle = NULL;
@@ -39,7 +39,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
  * Uncomment these line if use custom initialization commands.
  * The array should be declared as static const and positioned outside the function.
  */
-// static const ST77916_lcd_init_cmd_t lcd_init_cmds[] = {
+// static const st77916_lcd_init_cmd_t lcd_init_cmds[] = {
 // //  {cmd, { data }, data_size, delay_ms}
 //  {0xF0, (uint8_t []){0x08}, 1, 0},
 //  {0xF2, (uint8_t []){0x08}, 1, 0},
@@ -50,9 +50,9 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install ST77916 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    ST77916_vendor_config_t vendor_config = {
+    const st77916_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
-        // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(ST77916_lcd_init_cmd_t),
+        // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(st77916_lcd_init_cmd_t),
         .flags = {
             .use_qspi_interface = 0,
         },
@@ -73,12 +73,12 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize QSPI bus");
-    const esp_lcd_panel_io_spi_config_t io_config = ST77916_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA0,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA1,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA2,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA3
-                                                                                 EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
+    const spi_bus_config_t buscfg = ST77916_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA0,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA1,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA2,
+                                                                    EXAMPLE_PIN_NUM_LCD_DATA3,
+                                                                    EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
     ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
     ESP_LOGI(TAG, "Install panel IO");
@@ -90,7 +90,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
  * Uncomment these line if use custom initialization commands.
  * The array should be declared as static const and positioned outside the function.
  */
-// static const ST77916_lcd_init_cmd_t lcd_init_cmds[] = {
+// static const st77916_lcd_init_cmd_t lcd_init_cmds[] = {
 // //  {cmd, { data }, data_size, delay_ms}
 //  {0xF0, (uint8_t []){0x08}, 1, 0},
 //  {0xF2, (uint8_t []){0x08}, 1, 0},
@@ -101,9 +101,9 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install ST77916 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    ST77916_vendor_config_t vendor_config = {
+    const st77916_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
-        // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(ST77916_lcd_init_cmd_t),
+        // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(st77916_lcd_init_cmd_t),
         .flags = {
             .use_qspi_interface = 1,
         },

--- a/components/display/lcd/esp_lcd_st77922/README.md
+++ b/components/display/lcd/esp_lcd_st77922/README.md
@@ -28,8 +28,8 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize SPI bus");
-    const spi_bus_config_t bus_config = ST77922_PANEL_BUS_SPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK, EXAMPLE_PIN_NUM_LCD_DATA0, EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
-    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &bus_config, SPI_DMA_CH_AUTO));
+    const spi_bus_config_t buscfg = ST77922_PANEL_BUS_SPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK, EXAMPLE_PIN_NUM_LCD_DATA0, EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
+    ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
     ESP_LOGI(TAG, "Install panel IO");
     esp_lcd_panel_io_handle_t io_handle = NULL;
@@ -52,7 +52,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install st77922 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    st77922_vendor_config_t vendor_config = {
+    const st77922_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(st77922_lcd_init_cmd_t),
         .flags = {
@@ -75,11 +75,11 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
 ```c
     ESP_LOGI(TAG, "Initialize QSPI bus");
-    const esp_lcd_panel_io_spi_config_t io_config = ST77922_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
+    const spi_bus_config_t buscfg = ST77922_PANEL_BUS_QSPI_CONFIG(EXAMPLE_PIN_NUM_LCD_PCLK,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA0,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA1,
                                                                                  EXAMPLE_PIN_NUM_LCD_DATA2,
-                                                                                 EXAMPLE_PIN_NUM_LCD_DATA3
+                                                                                 EXAMPLE_PIN_NUM_LCD_DATA3,
                                                                                  EXAMPLE_LCD_H_RES * 80 * sizeof(uint16_t));
     ESP_ERROR_CHECK(spi_bus_initialize(EXAMPLE_LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
 
@@ -103,7 +103,7 @@ Alternatively, you can create `idf_component.yml`. More is in [Espressif's docum
 
     ESP_LOGI(TAG, "Install st77922 panel driver");
     esp_lcd_panel_handle_t panel_handle = NULL;
-    st77922_vendor_config_t vendor_config = {
+    const st77922_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,         // Uncomment these line if use custom initialization commands
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(st77922_lcd_init_cmd_t),
         .flags = {
@@ -196,7 +196,7 @@ void lvgl_port_rounder_callback(struct _lv_disp_drv_t * disp_drv, lv_area_t * ar
         };
         rgb_config.timings.h_res = EXAMPLE_LCD_H_RES;
         rgb_config.timings.v_res = EXAMPLE_LCD_V_RES;
-        st77922_vendor_config_t vendor_config = {
+        const st77922_vendor_config_t vendor_config = {
             .rgb_config = &rgb_config,
             .flags = {
                 .use_rgb_interface = 1,
@@ -252,7 +252,7 @@ void lvgl_port_rounder_callback(struct _lv_disp_drv_t * disp_drv, lv_area_t * ar
     ESP_LOGI(TAG, "Install LCD driver of st77922");
     esp_lcd_panel_handle_t panel_handle = NULL;
     esp_lcd_dpi_panel_config_t dpi_config = ST77922_480_360_PANEL_60HZ_DPI_CONFIG(EXAMPLE_MIPI_DPI_PX_FORMAT);
-    st77922_vendor_config_t vendor_config = {
+    const st77922_vendor_config_t vendor_config = {
         // .init_cmds = lcd_init_cmds,      // Uncomment these line if use custom initialization commands
         // .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(st77922_lcd_init_cmd_t),
         .flags.use_mipi_interface = 1,


### PR DESCRIPTION
## Description

This PR addresses and resolves errors in the initialization process of several LCD component descriptions

## Related
none

## Testing
I used ESP-IDF to add the corresponding LCD components and copied the relevant initialization code.

The incorrect descriptions caused compilation errors, requiring manual modifications to proceed. These changes ensure proper initialization and resolve the build issues.
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
