### PR TITLE
add config to disable gpio button internal pull resistor (AEGHB-917)

### DIFF
--- a/components/button/CHANGELOG.md
+++ b/components/button/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## v3.5.0 - 2024-12-27
+
+### Enhancements:
+
+* Add config to disable gpio button internal pull resistor.
+
 ## v3.4.1 - 2024-12-6
 
 ### Fix:

--- a/components/button/button_gpio.c
+++ b/components/button/button_gpio.c
@@ -26,12 +26,17 @@ esp_err_t button_gpio_init(const button_gpio_config_t *config)
     gpio_conf.intr_type = GPIO_INTR_DISABLE;
     gpio_conf.mode = GPIO_MODE_INPUT;
     gpio_conf.pin_bit_mask = (1ULL << config->gpio_num);
-    if (config->active_level) {
-        gpio_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
-        gpio_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+    if(config->disable_pull) {
+		gpio_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+		gpio_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     } else {
-        gpio_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-        gpio_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+        if (config->active_level) {
+            gpio_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
+            gpio_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+        } else {
+            gpio_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+            gpio_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+        }
     }
     gpio_config(&gpio_conf);
 

--- a/components/button/idf_component.yml
+++ b/components/button/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.4.1"
+version: "3.5.0"
 description: GPIO and ADC button driver
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/button
 repository: https://github.com/espressif/esp-iot-solution.git

--- a/components/button/include/button_gpio.h
+++ b/components/button/include/button_gpio.h
@@ -21,6 +21,7 @@ typedef struct {
 #if CONFIG_GPIO_BUTTON_SUPPORT_POWER_SAVE
     bool enable_power_save;        /**< enable power save mode */
 #endif
+    bool disable_pull;            /**< disable internal pull or not */
 } button_gpio_config_t;
 
 /**


### PR DESCRIPTION
When there is a external pull up / down resistor, we don't need the internal pull resistor, so we need a way to disable the internal pull resistor.