### PR TITLE
esp_tinyuf2: fix nvs hidden key

### DIFF
--- a/components/usb/esp_tinyuf2/esp_tinyuf2.h
+++ b/components/usb/esp_tinyuf2/esp_tinyuf2.h
@@ -118,7 +118,7 @@ void esp_restart_from_tinyuf2(void);
  * @return
  *      - ESP_OK: Operation was successful.
  */
-esp_err_t esp_tinyuf2_set_all_key_hidden(bool if_hidden)
+esp_err_t esp_tinyuf2_set_all_key_hidden(bool);
 
 /**
  * @brief Add a key to the hidden keys list.
@@ -134,7 +134,7 @@ esp_err_t esp_tinyuf2_set_all_key_hidden(bool if_hidden)
  *      - ESP_ERR_INVALID_ARG: Provided key is NULL.
  *      - ESP_ERR_NO_MEM: Memory allocation failed or maximum number of hidden keys exceeded.
  */
-esp_err_t esp_tinyuf2_add_key_hidden(const char *key)
+esp_err_t esp_tinyuf2_add_key_hidden(const char *);
 #endif
 
 #ifdef __cplusplus

--- a/components/usb/esp_tinyuf2/uf2/board_flash.c
+++ b/components/usb/esp_tinyuf2/uf2/board_flash.c
@@ -65,7 +65,7 @@ static nvs_modified_cb_t _modified_cb = NULL;
 static char _part_name[16] = "";
 static char _namespace_name[16] = "";
 #ifdef CONFIG_UF2_INI_NVS_VALUE_HIDDEN
-char *HIDDEN_STR[CONFIG_UF2_INI_NVS_HIDDEN_MAX_NUM];
+char *hidden_str[CONFIG_UF2_INI_NVS_HIDDEN_MAX_NUM];
 size_t hidden_str_num = 0;
 bool if_all_hidden = false;
 #endif
@@ -232,7 +232,7 @@ static void ini_gen_from_nvs(const char *part, const char *name)
             char *str = (char *)malloc(len);
             if ((result = nvs_get_str(nvs, info.key, str, &len)) == ESP_OK) {
 #ifdef CONFIG_UF2_INI_NVS_VALUE_HIDDEN
-                if (!check_value_if_hidden(info.key)) {
+                if (check_value_if_hidden(info.key)) {
                     ini_insert_pair(info.key, "****");
                 } else
 #endif


### PR DESCRIPTION
## Description

Allows the use of hidden NVS keys in the uf2 config.ini.
Also fixes an error where NVS entries intended to be hidden would be shown, and entries intended to be shown would be hidden. 
