### PR TITLE
Fixed axs15231b use i2c_master   SCL frequency error (AEGHB-1000)

### DIFF
--- a/components/display/lcd/esp_lcd_axs15231b/CHANGELOG.md
+++ b/components/display/lcd/esp_lcd_axs15231b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # ChangeLog
 
+## v1.0.1 - 2025-03-09
+
+### bugfix:
+
+- Fixed an issue where using i2c_master could not set scl_speed_hz resulting in an invalid scl frequency error
+
 ## v1.0.0 - 2024-02-29
 
 ### Enhancements:
 
-* Implement the driver for the AXS15231B LCD controller
-
+- Implement the driver for the AXS15231B LCD controller

--- a/components/display/lcd/esp_lcd_axs15231b/include/esp_lcd_axs15231b.h
+++ b/components/display/lcd/esp_lcd_axs15231b/include/esp_lcd_axs15231b.h
@@ -176,16 +176,17 @@ esp_err_t esp_lcd_touch_new_i2c_axs15231b(const esp_lcd_panel_io_handle_t io, co
  * @brief Touch IO configuration structure
  *
  */
-#define ESP_LCD_TOUCH_IO_I2C_AXS15231B_CONFIG()             \
-    {                                                       \
-        .dev_addr = ESP_LCD_TOUCH_IO_I2C_AXS15231B_ADDRESS, \
-        .control_phase_bytes = 1,                           \
-        .dc_bit_offset = 0,                                 \
-        .lcd_cmd_bits = 8,                                  \
-        .flags =                                            \
-        {                                                   \
-            .disable_control_phase = 1,                     \
-        }                                                   \
+#define ESP_LCD_TOUCH_IO_I2C_AXS15231B_CONFIG(scl_speed_hz)     \
+    {                                                           \
+        .dev_addr = ESP_LCD_TOUCH_IO_I2C_AXS15231B_ADDRESS,     \
+        .control_phase_bytes = 1,                               \
+        .dc_bit_offset = 0,                                     \
+        .lcd_cmd_bits = 8,                                      \
+        .flags =                                                \
+        {                                                       \
+            .disable_control_phase = 1,                         \
+        },                                                      \
+        .scl_speed_hz = scl_speed_hz,                           \
     }
 
 #ifdef __cplusplus


### PR DESCRIPTION
…lting in an invalid scl frequency error

 

## Description
 AXS15231B uses the new i2c_master driver to report SCL frequency error
```javascript
 const esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_AXS15231B_CONFIG();

ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c(i2c_bus_handle, &tp_io_config, &tp_io_handle), TAG, "");
ESP_RETURN_ON_ERROR(esp_lcd_touch_new_i2c_axs15231b(tp_io_handle, &tp_cfg, &tp_handle), TAG,  "New axs15231b failed");
 ```
 

## Related

 

## Testing

It works fine after passing scl_speed_hz
```
    const esp_lcd_panel_io_i2c_config_t tp_io_config = {
        .dev_addr = ESP_LCD_TOUCH_IO_I2C_AXS15231B_ADDRESS,
        .control_phase_bytes = 1,
        .dc_bit_offset = 0,
        .lcd_cmd_bits = 8,
        .flags =
            {
                .disable_control_phase = 1,
            },
        .scl_speed_hz = 400 * 1000
    };
```
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
