### PR TITLE
feat(button): matrix with inverted row scan levels (AEGHB-1005)

### DIFF
--- a/components/button/include/button_matrix.h
+++ b/components/button/include/button_matrix.h
@@ -37,6 +37,7 @@ typedef struct {
     int32_t *col_gpios;        /**< GPIO number list for the column */
     uint32_t row_gpio_num;     /**< Number of GPIOs associated with the row */
     uint32_t col_gpio_num;     /**< Number of GPIOs associated with the column */
+    bool scan_inverted;        /**< Inverted GPIO levels (pulse low) for row scanning */
 } button_matrix_config_t;
 
 /**


### PR DESCRIPTION
This PR extends button matrix with inverted levels (low pulse) for the row scan. It introduces a new flag `scan_inverted` in `button_matrix_config_t` that controls this behaviour.

Button matrix hardware variants with blocking diode cathodes on the row GPIOs require a low pulse on the currently scanned row and a pull-up resistor on the column GPIOs. The current button matrix implementation uses a high pulse on the row GPIO, which only works for the described hardware variant if row and column GPIOs are swapped (i. e. hardware rows become software columns and vice versa).

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
