### PR TITLE
fix(button): include stdbool.h before using bool (AEGHB-1006)

### DIFF
--- a/components/button/interface/button_interface.h
+++ b/components/button/interface/button_interface.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "esp_err.h"
 


### PR DESCRIPTION
## Description

This PR fixes a compilation error that occurs if `button_interface.h` is (directly or indirectly) included before `stdbool.h`. In this situation, the `bool` type (used in `button_interface.h`) is not yet known to the compiler.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
