### PR TITLE
fix(iot_usbh_cdc): Close 'extern C' block (AEGHB-1008)

### DIFF
--- a/components/usb/iot_usbh_cdc/include/iot_usbh_cdc.h
+++ b/components/usb/iot_usbh_cdc/include/iot_usbh_cdc.h
@@ -266,4 +266,5 @@ esp_err_t usbh_cdc_get_state(usbh_cdc_handle_t cdc_handle, usbh_cdc_state_t *sta
 esp_err_t usbh_cdc_desc_print(usbh_cdc_handle_t cdc_handle);
 
 #ifdef __cplusplus
+}
 #endif


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description


This PR fixes the issue by adding missed "}" at the end of the file.

Example error before the fix:
```CPP
[EDITED]/managed_components/espressif__iot_usbh_cdc/include/iot_usbh_cdc.h:13:1: note: 'extern "C"' linkage started here
   13 | extern "C" {
      | ^~~~~~~~~~
/home/auster/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20240530/xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/algorithmfwd.h:631:3: error: template with C linkage
  631 |   template<typename _RAIter>
      |   ^~~~~~~~
[EDITED]/managed_components/espressif__iot_usbh_cdc/include/iot_usbh_cdc.h:13:1: note: 'extern "C"' linkage started here
   13 | extern "C" {
      | ^~~~~~~~~~
/home/auster/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20240530/xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/algorithmfwd.h:636:3: error: template with C linkage
  636 |   template<typename _RAIter, typename _Compare>
      |   ^~~~~~~~
[EDITED]/managed_components/espressif__iot_usbh_cdc/include/iot_usbh_cdc.h:13:1: note: 'extern "C"' linkage started here
   13 | extern "C" {
      | ^~~~~~~~~~
/home/auster/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20240530/xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/algorithmfwd.h:642:3: error: template with C linkage
  642 |   template<typename _BIter, typename _Predicate>
      |   ^~~~~~~~
[EDITED]/managed_components/espressif__iot_usbh_cdc/include/iot_usbh_cdc.h:13:1: note: 'extern "C"' linkage started here
   13 | extern "C" {
      | ^~~~~~~~~~
/home/auster/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20240530/xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/algorithmfwd.h:661:3: error: template with C linkage
  661 |   template<typename _FIter1, typename _FIter2>
      |   ^~~~~~~~
[EDITED]/managed_components/espressif__iot_usbh_cdc/include/iot_usbh_cdc.h:13:1: note: 'extern "C"' linkage started here
   13 | extern "C" {
      | ^~~~~~~~~~
/home/auster/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20240530/xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/algorithmfwd.h:668:3: error: template with C linkage
  668 |   template<typename _FIter>

```

After the fix, the error is gone.


<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
