### PR TITLE
fix(button): Added initialization for gpio_config

### DIFF
--- a/components/button/button_gpio.c
+++ b/components/button/button_gpio.c
@@ -88,7 +88,7 @@ esp_err_t iot_button_new_gpio_device(const button_config_t *button_config, const
     gpio_btn->active_level = gpio_cfg->active_level;
     gpio_btn->enable_power_save = gpio_cfg->enable_power_save;
 
-    gpio_config_t gpio_conf;
+    gpio_config_t gpio_conf = {0};
     gpio_conf.intr_type = GPIO_INTR_DISABLE;
     gpio_conf.mode = GPIO_MODE_INPUT;
     gpio_conf.pin_bit_mask = (1ULL << gpio_cfg->gpio_num);


### PR DESCRIPTION
## Description

Initializes the gpio_config_t to all zeros, to prevent random value being left in the pull member values of the struct, since they are not set if `gpio_cfg->disable_pull` is set to `true`.

## Related

Caused this [issue](https://github.com/espressif/esp-bsp/issues/547).

## Testing

I have tested the change by making this line change in the managed_components directory of the example I show in the linked Issue

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
