### PR TITLE
Fix the esp_lcd_dpi_panel_config_t intialization order

### DIFF
--- a/components/display/lcd/esp_lcd_ek79007/include/esp_lcd_ek79007.h
+++ b/components/display/lcd/esp_lcd_ek79007/include/esp_lcd_ek79007.h
@@ -95,22 +95,22 @@ esp_err_t esp_lcd_new_panel_ek79007(const esp_lcd_panel_io_handle_t io, const es
  */
 #define EK79007_1024_600_PANEL_60HZ_CONFIG(px_format)            \
     {                                                            \
+        .virtual_channel = 0,                                    \
         .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,             \
         .dpi_clock_freq_mhz = 52,                                \
-        .virtual_channel = 0,                                    \
         .pixel_format = px_format,                               \
         .num_fbs = 1,                                            \
         .video_timing = {                                        \
             .h_size = 1024,                                      \
             .v_size = 600,                                       \
-            .hsync_back_porch = 160,                             \
             .hsync_pulse_width = 10,                             \
+            .hsync_back_porch = 160,                             \
             .hsync_front_porch = 160,                            \
-            .vsync_back_porch = 23,                              \
             .vsync_pulse_width = 1,                              \
+            .vsync_back_porch = 23,                              \
             .vsync_front_porch = 12,                             \
         },                                                       \
-        .flags.use_dma2d = true,                                 \
+        .flags = { .use_dma2d = true, },                         \
     }
 
 #ifdef __cplusplus


### PR DESCRIPTION
EK79007_1024_600_PANEL_60HZ_CONFIG  initializes the esp_lcd_dpi_panel_config_t in the wrong order, which causes more picky compilers to raise an error.

## Description

The initialization order (and method) of EK79007_1024_600_PANEL_60HZ_CONFIG isn't exactly as the esp_lcd_dpi_panel_config_t type definition, which causes some compilers (or newer ESP-IDF versions) to raise an error about intialization order and completeness, which breaks the build.
This PR corrects the order and adds a matching flags definition.


## Checklist

Before submitting a Pull Request, please ensure the following:

- [ X] 🚨 This PR does not introduce breaking changes.
- [ TBD] All CI checks (GH Actions) pass.
- [ X] Documentation is updated as needed.
- [ X] Tests are updated or added as necessary.
- [X ] Code is well-commented, especially in complex areas.
- [ X] Git history is clean — commits are squashed to the minimum necessary.
