### PR TITLE
fix(ina236): negative current handling (AEGHB-1101)

### DIFF
--- a/components/sensors/power_monitor/ina236/ina236.c
+++ b/components/sensors/power_monitor/ina236/ina236.c
@@ -133,11 +133,7 @@ esp_err_t ina236_get_current(ina236_handle_t handle, float *curr)
     uint16_t buffer = 0;
     ina236_t *ina236 = (ina236_t *)handle;
     ina236_read_reg(ina236, INA236_REG_VSHUNT, &buffer);
-    if ((buffer & 0x8000) >> 15) {
-        *curr = 0;
-    } else {
-        *curr = buffer / 3970.0f;
-    }
+    *curr = (int16_t)buffer / 3970.0f;
     return ESP_OK;
 }
 


### PR DESCRIPTION
I recently made board with ESP32-S3 and INA236 sensor. My current shunt polarity was inverted thus current readings were nominally negative. The sensor returns the value as a standard two's complement int16. The current implementation detects that the negative sign bit is set and ignores the reading and returns 0. This commit fixes the handling of this value by simply casting the value to int16_t before doing the scaling. The commit was tested on my board.