### PR TITLE
Fix secondary data dump, typos (AEGHB-1117)

### DIFF
--- a/components/usb/iot_usbh_modem/src/esp_modem_usb_dte.c
+++ b/components/usb/iot_usbh_modem/src/esp_modem_usb_dte.c
@@ -163,11 +163,11 @@ static void esp_handle_usb2_data(esp_modem_dte_internal_t *esp_dte)
     }
     length = MIN(esp_dte->data_buffer_size, length);
     uint8_t *temp_buffer = (uint8_t *)calloc(1, length);
-    usbh_cdc_read_bytes(esp_dte->cdc_hdl2, esp_dte->data_buffer, &length, pdMS_TO_TICKS(100));
+    usbh_cdc_read_bytes(esp_dte->cdc_hdl2, temp_buffer, &length, pdMS_TO_TICKS(100));
     /* pass the input data to configured callback */
     if (length) {
-        ESP_LOGI(TAG, "Intf2 not handle date, just dump:");
-        ESP_LOG_BUFFER_HEXDUMP("esp-modem-dte: inf2", temp_buffer, length, ESP_LOG_INFO);
+        ESP_LOGI(TAG, "Unsolicited data on secondary itf, dumping:");
+        ESP_LOG_BUFFER_HEXDUMP("esp-modem-dte: intf2", temp_buffer, length, ESP_LOG_INFO);
     }
     free(temp_buffer);
 }


### PR DESCRIPTION


## Description

Unsolicited data on secondary interface was not dumped to terminal, just zeroes
eg with secondary interface set to interface 1 on SIM7600 (NMEA sentences every second), console dumps

```
I (31055) 4g_main: rssi=99, ber=99
I (31555) esp-modem-dte: Intf2 not handle date, just dump:
I (31555) esp-modem-dte: inf2: 0x3fcd0aa4   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31561) esp-modem-dte: inf2: 0x3fcd0ab4   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31572) esp-modem-dte: inf2: 0x3fcd0ac4   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31582) esp-modem-dte: inf2: 0x3fcd0ad4   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31593) esp-modem-dte: inf2: 0x3fcd0ae4   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31604) esp-modem-dte: inf2: 0x3fcd0af4   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31615) esp-modem-dte: inf2: 0x3fcd0b04   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31626) esp-modem-dte: inf2: 0x3fcd0b14   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31637) esp-modem-dte: inf2: 0x3fcd0b24   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31648) esp-modem-dte: inf2: 0x3fcd0b34   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31658) esp-modem-dte: inf2: 0x3fcd0b44   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31669) esp-modem-dte: inf2: 0x3fcd0b54   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31680) esp-modem-dte: inf2: 0x3fcd0b64   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
I (31691) esp-modem-dte: inf2: 0x3fcd0b74   00 00 00 00 00 00 00                              |.......|
```

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
After fix, console dumps
```
I (40703) 4g_main: rssi=99, ber=99
I (41502) esp-modem-dte: Unsolicited data on secondary itf, dumping:
I (41502) esp-modem-dte: intf2: 0x3fcd0a74   24 47 4e 47 4e 53 2c 2c  2c 2c 2c 2c 4e 4e 4e 2c  |$GNGNS,,,,,,NNN,|
I (41509) esp-modem-dte: intf2: 0x3fcd0a84   2c 2c 2c 2c 2c 2a 31 44  0d 0a 24 47 50 56 54 47  |,,,,,*1D..$GPVTG|
I (41520) esp-modem-dte: intf2: 0x3fcd0a94   2c 2c 54 2c 2c 4d 2c 2c  4e 2c 2c 4b 2c 4e 2a 32  |,,T,,M,,N,,K,N*2|
I (41531) esp-modem-dte: intf2: 0x3fcd0aa4   43 0d 0a 24 47 50 47 53  41 2c 41 2c 31 2c 2c 2c  |C..$GPGSA,A,1,,,|
I (41542) esp-modem-dte: intf2: 0x3fcd0ab4   2c 2c 2c 2c 2c 2c 2c 2c  2c 2c 2c 2c 2c 2a 33 32  |,,,,,,,,,,,,,*32|
I (41552) esp-modem-dte: intf2: 0x3fcd0ac4   0d 0a 24 47 4e 47 53 41  2c 41 2c 31 2c 2c 2c 2c  |..$GNGSA,A,1,,,,|
I (41563) esp-modem-dte: intf2: 0x3fcd0ad4   2c 2c 2c 2c 2c 2c 2c 2c  2c 2c 2c 2c 2a 32 43 0d  |,,,,,,,,,,,,*2C.|
I (41574) esp-modem-dte: intf2: 0x3fcd0ae4   0a 24 42 44 47 53 41 2c  41 2c 31 2c 2c 2c 2c 2c  |.$BDGSA,A,1,,,,,|
I (41585) esp-modem-dte: intf2: 0x3fcd0af4   2c 2c 2c 2c 2c 2c 2c 2c  2c 2c 2a 30 46 0d 0a 24  |,,,,,,,,,,*0F..$|
I (41596) esp-modem-dte: intf2: 0x3fcd0b04   47 50 47 47 41 2c 2c 2c  2c 2c 2c 30 2c 2c 2c 2c  |GPGGA,,,,,,0,,,,|
I (41607) esp-modem-dte: intf2: 0x3fcd0b14   2c 2c 2c 2c 2a 36 36 0d  0a 24 50 51 58 46 49 2c  |,,,,*66..$PQXFI,|
I (41618) esp-modem-dte: intf2: 0x3fcd0b24   2c 2c 2c 2c 2c 2c 2c 2c  2c 2a 35 36 0d 0a 24 47  |,,,,,,,,,*56..$G|
I (41629) esp-modem-dte: intf2: 0x3fcd0b34   50 52 4d 43 2c 2c 56 2c  2c 2c 2c 2c 2c 2c 2c 2c  |PRMC,,V,,,,,,,,,|
I (41640) esp-modem-dte: intf2: 0x3fcd0b44   2c 4e 2a 35 33 0d 0a                              |,N*53..|

```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [✓ ] 🚨 This PR does not introduce breaking changes.
- [ ✓] All CI checks (GH Actions) pass.
- [ ✓] Documentation is updated as needed.
- [✓ ] Tests are updated or added as necessary.
- [ ✓] Code is well-commented, especially in complex areas.
- [ ✓] Git history is clean — commits are squashed to the minimum necessary.
