### PR TITLE
fix: add #include <stdbool.h> and parentheses (AEGHB-1143)

### DIFF
--- a/components/knob/include/iot_knob.h
+++ b/components/knob/include/iot_knob.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "esp_err.h"
 
 #ifdef __cplusplus

--- a/components/knob/iot_knob.c
+++ b/components/knob/iot_knob.c
@@ -218,8 +218,8 @@ static void knob_cb(void *args)
             if (target->enable_power_save) {
                 knob_gpio_wake_up_control((uint32_t)target->encoder_a, !target->encoder_a_level, true);
                 knob_gpio_wake_up_control((uint32_t)target->encoder_b, !target->encoder_b_level, true);
-                knob_gpio_set_intr((uint32_t)target->encoder_a, !target->encoder_a_level == 0 ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
-                knob_gpio_set_intr((uint32_t)target->encoder_b, !target->encoder_b_level == 0 ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
+                knob_gpio_set_intr((uint32_t)target->encoder_a, !(target->encoder_a_level == 0) ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
+                knob_gpio_set_intr((uint32_t)target->encoder_b, !(target->encoder_b_level == 0) ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
                 knob_gpio_intr_control((uint32_t)(target->encoder_a), true);
                 knob_gpio_intr_control((uint32_t)(target->encoder_b), true);
             }
@@ -262,8 +262,8 @@ knob_handle_t iot_knob_create(const knob_config_t *config)
 
     if (config->enable_power_save) {
         knob->enable_power_save = config->enable_power_save;
-        knob_gpio_init_intr(config->gpio_encoder_a, !knob->encoder_a_level == 0 ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL, knob_power_save_isr_handler, knob->encoder_a);
-        knob_gpio_init_intr(config->gpio_encoder_b, !knob->encoder_b_level == 0 ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL, knob_power_save_isr_handler, knob->encoder_b);
+        knob_gpio_init_intr(config->gpio_encoder_a, !(knob->encoder_a_level == 0) ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL, knob_power_save_isr_handler, knob->encoder_a);
+        knob_gpio_init_intr(config->gpio_encoder_b, !(knob->encoder_b_level == 0) ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL, knob_power_save_isr_handler, knob->encoder_b);
 
         ret = knob_gpio_wake_up_init(config->gpio_encoder_a, !knob->encoder_a_level);
         KNOB_CHECK_GOTO(ESP_OK == ret, "encoder A wake up gpio init failed", _encoder_deinit);


### PR DESCRIPTION
## Description

This pull request fixes compilation errors in the `espressif__knob` component.

The Clang compiler was producing errors due to incorrect use of the logical NOT operator `!` applied directly before a comparison (`== 0`), which caused ambiguity and warnings treated as errors.

To resolve this, parentheses were added around the expression to clarify the intended logic. Additionally, the `<stdbool.h>` header was included in `iot_knob.h` to properly define the `bool` type, which was previously causing an unknown type error during compilation.

---

## Related

No specific open issues related to this PR.  
This PR addresses build errors that prevented using the `espressif__knob` component with recent versions of Clang (esp-clang version `esp-18.1.2_20240912`).

---

## Testing

The firmware was compiled locally using the ESP-IDF toolchain with Clang 18.1.2 without any compilation errors.  
The functionality of the `espressif__knob` component was tested in the application and behaved as expected.

---

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.  
- [x] All CI checks (GitHub Actions) pass.  
- [x] Documentation is updated as needed (not applicable for this fix).  
- [x] Tests are updated or added if necessary (not applicable).  
- [x] Code is well-commented, especially in complex areas.  
- [x] Git history is clean — commits are concise and minimal.
