### PR TITLE
fix: AHT20 - remove incorrect check for CRC bit (AEGHB-1314)

### DIFF
--- a/components/sensors/humiture/aht20/aht20.c
+++ b/components/sensors/humiture/aht20/aht20.c
@@ -69,7 +69,6 @@ esp_err_t aht20_read_temperature_humidity(aht20_dev_handle_t handle,
     ESP_RETURN_ON_ERROR(aht20_read_reg(handle, &status, 1), TAG, "I2C read error");
 
     if ((status & BIT(AT581X_STATUS_Calibration_Enable)) &&
-            (status & BIT(AT581X_STATUS_CRC_FLAG)) &&
             ((status & BIT(AT581X_STATUS_BUSY_INDICATION)) == 0)) {
         ESP_RETURN_ON_ERROR(aht20_read_reg(handle, buf, 7), TAG, "I2C read error");
         ESP_RETURN_ON_ERROR((aht20_calc_crc(buf, 6) != buf[6]), TAG, "crc is error");

--- a/components/sensors/humiture/aht20/idf_component.yml
+++ b/components/sensors/humiture/aht20/idf_component.yml
@@ -1,4 +1,4 @@
-version: 2.0.0
+version: 2.0.1
 description: I2C driver for AHT20 humidity and temperature sensor
 issues: https://github.com/espressif/esp-iot-solution/issues
 repository: git://github.com/espressif/esp-iot-solution.git

--- a/components/sensors/humiture/aht20/priv_include/aht20_reg.h
+++ b/components/sensors/humiture/aht20/priv_include/aht20_reg.h
@@ -19,6 +19,5 @@
 
 #define AT581X_STATUS_CMP_INT               (2)             /* 1 --Out threshold range; 0 --In threshold range */
 #define AT581X_STATUS_Calibration_Enable    (3)             /* 1 --Calibration enable; 0 --Calibration disable */
-#define AT581X_STATUS_CRC_FLAG              (4)             /* 1 --CRC ok; 0 --CRC failed */
 #define AT581X_STATUS_MODE_STATUS           (5)             /* 00 -NOR mode; 01 -CYC mode; 1x --CMD mode */
 #define AT581X_STATUS_BUSY_INDICATION       (7)             /* 1 --Equipment is busy; 0 --Equipment is idle */


### PR DESCRIPTION
## Description

There was a incorrect check for a CRC bit in the response from the sensor. 

This bit is NOT defined in the datasheet and some versions of the chip don't set this bit. 

<img width="400" height="258" alt="image" src="https://github.com/user-attachments/assets/04c3dbc7-5925-4637-9f13-20cde10ba11b" />

## Related
[Datasheet](https://asairsensors.com/wp-content/uploads/2021/09/Data-Sheet-AHT20-Humidity-and-Temperature-Sensor-ASAIR-V1.0.03.pdf)

## Testing

As it's just the removable of a wrong check, I just tested it in my test project, 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
