### PR TITLE
Change learn_param to dynamic allocation (AEGHB-1335)

### DIFF
--- a/components/ir/ir_learn/CHANGELOG.md
+++ b/components/ir/ir_learn/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v1.0.1 - 2025-12-24
+
+* Change learn_param to dynamic allocation
+
 ## v1.0.0 - 2024-08-09
 
 * Update README

--- a/components/ir/ir_learn/idf_component.yml
+++ b/components/ir/ir_learn/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 targets:
   - esp32c3
   - esp32c6


### PR DESCRIPTION
Allocate memory for learn_param dynamically and check for allocation failure.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

- Fixes [#123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword](https://github.com/espressif/esp-iot-solution/issues/621)


## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
