### PR TITLE
fix: reorder endpoint reset logic in _cdc_close function (AEGHB-1339)

### DIFF
--- a/components/usb/iot_usbh_cdc/iot_usbh_cdc.c
+++ b/components/usb/iot_usbh_cdc/iot_usbh_cdc.c
@@ -807,14 +807,8 @@ static esp_err_t _cdc_close(usbh_cdc_t *cdc)
         ESP_ERROR_CHECK(_cdc_reset_transfer_endpoint(cdc->dev_hdl, cdc->data.in_xfer));
     }
 
-    ESP_ERROR_CHECK(_cdc_reset_transfer_endpoint(cdc->dev_hdl, cdc->data.out_xfer));
-
     if (cdc->notif.xfer) {
         ESP_ERROR_CHECK(_cdc_reset_transfer_endpoint(cdc->dev_hdl, cdc->notif.xfer));
-    }
-
-    if ((cdc->notif.intf_desc != NULL) && cdc->notif.intf_desc != cdc->data.intf_desc) {
-        ESP_ERROR_CHECK(usb_host_interface_release(p_usbh_cdc_obj->cdc_client_hdl, cdc->dev_hdl, cdc->notif.intf_desc->bInterfaceNumber));
     }
 
     if (cdc->data.out_xfer) {
@@ -823,6 +817,11 @@ static esp_err_t _cdc_close(usbh_cdc_t *cdc)
 
     // wait for transfers to complete
     vTaskDelay(10 / portTICK_PERIOD_MS);
+
+    if ((cdc->notif.intf_desc != NULL) && cdc->notif.intf_desc != cdc->data.intf_desc) {
+        ESP_ERROR_CHECK(usb_host_interface_release(p_usbh_cdc_obj->cdc_client_hdl, cdc->dev_hdl, cdc->notif.intf_desc->bInterfaceNumber));
+    }
+
     // Release all interfaces
     ESP_ERROR_CHECK(usb_host_interface_release(p_usbh_cdc_obj->cdc_client_hdl, cdc->dev_hdl, cdc->data.intf_desc->bInterfaceNumber));
 


### PR DESCRIPTION
## Description

fix: reorder endpoint reset logic in _cdc_close function

This change reorders the endpoint reset logic and interface release in the `_cdc_close` function to ensure correct resource release order and prevent potential errors during device closure.

## Related

Fixes #625 - [AEGHB-1338](https://github.com/espressif/esp-iot-solution/issues/625)

## Testing

I have tested the new code with the project's test app, and all tests passed successfully: "3 Tests 0 Failures 0 Ignored".

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
