### PR TITLE
fix(ble_conn_mgr): normalize SM capability bitmask to 0/1 for 1-bit ble_hs_cfg fields (AEGHB-1416)

### DIFF
--- a/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
+++ b/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
@@ -2188,11 +2188,11 @@ esp_err_t esp_ble_conn_start(void)
 
     /* Initialize security manager configuration in NimBLE host  */
 #ifdef CONFIG_BLE_CONN_MGR_SM
-    ble_hs_cfg.sm_io_cap = CONFIG_BLE_CONN_MGR_SM_IO_TYPE;;
-    ble_hs_cfg.sm_oob_data_flag = (CONFIG_BLE_CONN_MGR_SM_CAP & BIT(0));
-    ble_hs_cfg.sm_bonding = (CONFIG_BLE_CONN_MGR_SM_CAP & BIT(1));
-    ble_hs_cfg.sm_mitm = (CONFIG_BLE_CONN_MGR_SM_CAP & BIT(2));
-    ble_hs_cfg.sm_sc = (CONFIG_BLE_CONN_MGR_SM_CAP & BIT(3));
+    ble_hs_cfg.sm_io_cap = CONFIG_BLE_CONN_MGR_SM_IO_TYPE;
+    ble_hs_cfg.sm_oob_data_flag = !!(CONFIG_BLE_CONN_MGR_SM_CAP & BIT(0));
+    ble_hs_cfg.sm_bonding = !!(CONFIG_BLE_CONN_MGR_SM_CAP & BIT(1));
+    ble_hs_cfg.sm_mitm = !!(CONFIG_BLE_CONN_MGR_SM_CAP & BIT(2));
+    ble_hs_cfg.sm_sc = !!(CONFIG_BLE_CONN_MGR_SM_CAP & BIT(3));
     ble_hs_cfg.sm_our_key_dist = CONFIG_BLE_CONN_MGR_SM_KEY_DIST;
     ble_hs_cfg.sm_their_key_dist = CONFIG_BLE_CONN_MGR_SM_KEY_DIST;
 #else


### PR DESCRIPTION
Fixes #660

## Problem

The `ble_hs_cfg` security manager fields (`sm_bonding`, `sm_mitm`, `sm_sc`, `sm_oob_data_flag`) are declared as `unsigned :1` bitfields in NimBLE.

Assigning `(CONFIG_BLE_CONN_MGR_SM_CAP & BIT(n))` directly yields values like 2, 4, 8 — which are silently truncated to 0 when stored in a 1-bit field. This effectively **disables** the security features the user configured via Kconfig.

With ESP-IDF v5.5+ this also causes a build error with `-Werror=overflow`.

## Fix

Use `!!` (double negation) to normalize the bitmask result to 0 or 1:

```c
// Before (broken):
ble_hs_cfg.sm_bonding = (CONFIG_BLE_CONN_MGR_SM_CAP & BIT(1));  // yields 2 → truncated to 0

// After (correct):
ble_hs_cfg.sm_bonding = !!(CONFIG_BLE_CONN_MGR_SM_CAP & BIT(1));  // yields 1
```

Also fixes a cosmetic double semicolon on the `sm_io_cap` line.