### PR TITLE
fix(ble_conn_mgr): widen characteristic flag field from uint8_t to uint16_t (AEGHB-1415)

### DIFF
--- a/components/bluetooth/ble_conn_mgr/include/esp_ble_conn_mgr.h
+++ b/components/bluetooth/ble_conn_mgr/include/esp_ble_conn_mgr.h
@@ -276,6 +276,12 @@ esp_err_t esp_ble_conn_l2cap_coc_accept(uint16_t conn_handle, uint16_t peer_sdu_
 #define BLE_CONN_GATT_CHR_WRITE             0x0008  /*!< Characteristic write properties */
 #define BLE_CONN_GATT_CHR_NOTIFY            0x0010  /*!< Characteristic notify properties */
 #define BLE_CONN_GATT_CHR_INDICATE          0x0020  /*!< Characteristic indicate properties */
+#define BLE_CONN_GATT_CHR_READ_ENC          0x0200  /*!< Characteristic read requires encryption */
+#define BLE_CONN_GATT_CHR_READ_AUTHEN       0x0400  /*!< Characteristic read requires authentication */
+#define BLE_CONN_GATT_CHR_READ_AUTHOR       0x0800  /*!< Characteristic read requires authorization */
+#define BLE_CONN_GATT_CHR_WRITE_ENC         0x1000  /*!< Characteristic write requires encryption */
+#define BLE_CONN_GATT_CHR_WRITE_AUTHEN      0x2000  /*!< Characteristic write requires authentication */
+#define BLE_CONN_GATT_CHR_WRITE_AUTHOR      0x4000  /*!< Characteristic write requires authorization */
 
 /**
  * @brief This is type of function that will handle the registered characteristic
@@ -373,7 +379,7 @@ typedef union {
 typedef struct {
     const char *name;                               /*!< Name of the handler */
     uint8_t type;                                   /*!< Type of the UUID */
-    uint8_t flag;                                   /*!< Flag for visiting right */
+    uint16_t flag;                                  /*!< Flag for visiting right */
     esp_ble_conn_uuid_t uuid;                       /*!< Universal UUID, to be used for any-UUID static allocation */
     esp_ble_conn_cb_t  uuid_fn;                     /*!< BLE UUID callback */
 } esp_ble_conn_character_t;


### PR DESCRIPTION
## Problem

The `esp_ble_conn_character_t.flag` field is `uint8_t`, which silently truncates NimBLE security flags that exceed `0xFF`:

- `BLE_GATT_CHR_F_READ_ENC` = `0x0200`
- `BLE_GATT_CHR_F_READ_AUTHEN` = `0x0400`
- `BLE_GATT_CHR_F_WRITE_ENC` = `0x1000`
- `BLE_GATT_CHR_F_WRITE_AUTHEN` = `0x2000`
- etc.

This makes it impossible to set per-characteristic encryption/authentication requirements through the ble_conn_mgr API.

In `esp_nimble.c`, the field is directly assigned to NimBLE's `ble_gatt_chr_def.flags` which is `uint16_t` (`ble_gatt_chr_flags`):
```c
(characteristics + index)->flags = nu_lookup[index].flag;
```

## Fix

1. **Widen** `esp_ble_conn_character_t.flag` from `uint8_t` to `uint16_t` to match NimBLE's type
2. **Add** security flag convenience constants that mirror NimBLE's `BLE_GATT_CHR_F_*` values:
   - `BLE_CONN_GATT_CHR_READ_ENC` (0x0200)
   - `BLE_CONN_GATT_CHR_READ_AUTHEN` (0x0400)
   - `BLE_CONN_GATT_CHR_READ_AUTHOR` (0x0800)
   - `BLE_CONN_GATT_CHR_WRITE_ENC` (0x1000)
   - `BLE_CONN_GATT_CHR_WRITE_AUTHEN` (0x2000)
   - `BLE_CONN_GATT_CHR_WRITE_AUTHOR` (0x4000)

## Backward Compatibility

Fully backward compatible:
- All existing flag values (0x0001–0x0020) fit in both `uint8_t` and `uint16_t`
- Struct size may increase by 1 byte due to alignment, but this struct is not serialized or stored in NVS
- No source changes needed for existing users

Related to #660