### PR TITLE
feat(esp_lcd_sh8601): add brightness control to the panel (AEGHB-1429)

### DIFF
--- a/components/display/lcd/esp_lcd_sh8601/esp_lcd_sh8601.c
+++ b/components/display/lcd/esp_lcd_sh8601/esp_lcd_sh8601.c
@@ -35,6 +35,7 @@ static esp_err_t panel_sh8601_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool
 static esp_err_t panel_sh8601_swap_xy(esp_lcd_panel_t *panel, bool swap_axes);
 static esp_err_t panel_sh8601_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap);
 static esp_err_t panel_sh8601_disp_on_off(esp_lcd_panel_t *panel, bool off);
+static esp_err_t panel_sh8601_set_brightness(esp_lcd_panel_t *panel, int brightness);
 
 typedef struct {
     esp_lcd_panel_t base;
@@ -121,6 +122,7 @@ esp_err_t esp_lcd_new_panel_sh8601(const esp_lcd_panel_io_handle_t io, const esp
     sh8601->base.mirror = panel_sh8601_mirror;
     sh8601->base.swap_xy = panel_sh8601_swap_xy;
     sh8601->base.disp_on_off = panel_sh8601_disp_on_off;
+    sh8601->base.set_brightness = panel_sh8601_set_brightness;
     *ret_panel = &(sh8601->base);
     ESP_LOGD(TAG, "new sh8601 panel @%p", sh8601);
 
@@ -344,4 +346,15 @@ static esp_err_t panel_sh8601_disp_on_off(esp_lcd_panel_t *panel, bool on_off)
     }
     ESP_RETURN_ON_ERROR(tx_param(sh8601, io, command, NULL, 0), TAG, "send command failed");
     return ESP_OK;
+}
+
+static esp_err_t panel_sh8601_set_brightness(esp_lcd_panel_t *panel, int brightness)
+{
+    sh8601_panel_t *sh8601 = __containerof(panel, sh8601_panel_t, base);
+    esp_lcd_panel_io_handle_t io = sh8601->io;
+
+    // Clamp brightness to 0-1023 range (10-bit)
+    uint16_t brightness_val = (brightness < 0) ? 0 : (brightness > 1023) ? 1023 : (uint16_t)brightness;
+    // Send as 2 bytes: MSB and LSB
+    return tx_param(sh8601, io, LCD_CMD_WRDISBV, (uint8_t[]) { (brightness_val >> 8) & 0xFF, brightness_val & 0xFF }, 2);
 }


### PR DESCRIPTION

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Add display brightness controll
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
Goes with IDF https://github.com/espressif/esp-idf/pull/18273
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
