### PR TITLE
fix(bme280): fix bme280_read_altitude variable and unit bugs (AEGHB-1440)

### DIFF
--- a/components/sensors/pressure/bme280/bme280.c
+++ b/components/sensors/pressure/bme280/bme280.c
@@ -355,12 +355,10 @@ esp_err_t bme280_read_humidity(bme280_handle_t sensor, float *humidity)
 esp_err_t bme280_read_altitude(bme280_handle_t sensor, float seaLevel, float *altitude)
 {
     float pressure = 0.0;
-    float temp = 0.0;
-    if (bme280_read_pressure(sensor, &temp) != ESP_OK) {
+    if (bme280_read_pressure(sensor, &pressure) != ESP_OK) {
         return ESP_FAIL;
     }
-    float atmospheric = pressure / 100.0F;
-    *altitude = 44330.0 * (1.0 - pow(atmospheric / seaLevel, 0.1903));
+    *altitude = 44330.0 * (1.0 - pow(pressure / seaLevel, 0.1903));
     return ESP_OK;
 }
 


### PR DESCRIPTION
## Description

`bme280_read_altitude` had two bugs that made it always return incorrect results:

- Pressure was read into the unused temp variable instead of pressure, leaving pressure at 0.0
- pressure was then divided by 100 again despite bmp280_read_pressure already returning hPa, which would have produced an incorrect altitude even if the first bug were fixed