### PR TITLE
refactor(lightbulb_driver): stop including unstable hal/spi_hal.h

### DIFF
--- a/components/led/lightbulb_driver/drivers/sm16825e/sm16825e.c
+++ b/components/led/lightbulb_driver/drivers/sm16825e/sm16825e.c
@@ -8,7 +8,7 @@
 
 #include <esp_log.h>
 #include <driver/spi_master.h>
-#include <hal/spi_hal.h>
+#include "soc/spi_periph.h"
 #include <driver/gpio.h>
 #include "esp_heap_caps.h"
 #include "esp_idf_version.h"

--- a/components/led/lightbulb_driver/drivers/ws2812/ws2812.c
+++ b/components/led/lightbulb_driver/drivers/ws2812/ws2812.c
@@ -8,7 +8,7 @@
 
 #include <esp_log.h>
 #include <driver/spi_master.h>
-#include <hal/spi_hal.h>
+#include "soc/spi_periph.h"
 #include "esp_heap_caps.h"
 #include "esp_idf_version.h"
 #include "driver_utils.h"


### PR DESCRIPTION
Use soc/spi_periph.h for spi_periph_signal and SPI register access instead of pulling in the internal HAL master header. hal/spi_hal.h is not a stable application-facing API.

Affected: ws2812 and sm16825e SPI helpers.


