### PR TITLE
fix(button): handle GPIO ISR service installation idempotency

### DIFF
--- a/components/button/button_gpio.c
+++ b/components/button/button_gpio.c
@@ -56,7 +56,8 @@ static esp_err_t button_gpio_set_intr(int gpio_num, gpio_int_type_t intr_type, g
     ESP_RETURN_ON_FALSE(ret == ESP_OK, ret, TAG, "Set gpio interrupt type failed");
     if (!isr_service_installed) {
         ret = gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
-        ESP_RETURN_ON_FALSE(ret == ESP_OK, ret, TAG, "Install gpio interrupt service failed");
+        // ESP_ERR_INVALID_STATE = service previously installed by another component (idempotent)
+        ESP_RETURN_ON_FALSE((ret == ESP_OK) || (ret == ESP_ERR_INVALID_STATE), ret, TAG, "Install gpio interrupt service failed");
         isr_service_installed = true;
     }
     ret = gpio_isr_handler_add(gpio_num, isr_handler, (void *)gpio_num);


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

The GPIO ISR service installation is idempotent per ESP-IDF documentation. `ESP_ERR_INVALID_STATE` indicates the service was already installed by another component, so not a fatal error. This change allows `iot_button` to coexist with
other components that install the ISR service first by treating `ESP_ERR_INVALID_STATE` as success in `button_gpio_set_intr`. The existing `isr_service_installed` static flag is retained to avoid redundant calls after initial installation.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

No similar issues have been raised to my knowledge.

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

I haven't ran the test suite.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
