### PR TITLE
Fix version mismatch - Issue #704

### DIFF
--- a/components/display/tools/esp_lvgl_adapter/src/adapter/esp_lv_adapter.c
+++ b/components/display/tools/esp_lvgl_adapter/src/adapter/esp_lv_adapter.c
@@ -176,7 +176,7 @@ static esp_err_t adapter_stop_tick_timer(void)
     esp_timer_handle_t timer = (esp_timer_handle_t)s_ctx.tick_timer;
     esp_err_t ret;
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(6, 0, 0)
     ret = esp_timer_stop_blocking(timer, portMAX_DELAY);
     if (ret == ESP_ERR_NOT_FINISHED) {
         ret = ESP_OK;


### PR DESCRIPTION
The current change fixes the issue where the compiler reports error: esp_lvgl_adapter 0.4.3 implicit declaration of function 'esp_timer_stop_blocking' 

## Related issue
Fixes #704 

## Description
The problem is that the change made, is not compatible with the current esp-idf available which is v6.0.0, maybe the developer was targeting a higher/upcoming version.

To avoid this issue, a strict skip of esp-idf v6.0.0 is required so the implementation falls back to ret = esp_timer_stop(timer); which is still used this version (v6.0.0).