### PR TITLE
fix(log_router): stop buffer overrun

### DIFF
--- a/components/utilities/log_router/CHANGELOG.md
+++ b/components/utilities/log_router/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## v0.1.2 - 2026-05-15
+
+### Bug fix ###
+
+* Prevent buffer overrun when messages are truncated.
+* Stop wasting a byte at the end of the buffer.
+
 ## v0.1.1 - 2025-08-25
 
 ### Bug fix ###

--- a/components/utilities/log_router/idf_component.yml
+++ b/components/utilities/log_router/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.1"
+version: "0.1.2"
 description: LogRouter redirects and filters ESP logs to various storage media
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/utilities/log_router
 repository: https://github.com/espressif/esp-iot-solution.git

--- a/components/utilities/log_router/log_router.c
+++ b/components/utilities/log_router/log_router.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -122,8 +122,14 @@ int esp_log_router_flash_vprintf(const char *format, va_list args)
 
     // Write to all files that match the log level
     esp_log_router_slist_t *item;
-    int len = vsnprintf(vprintf_buffer, sizeof(vprintf_buffer) - 1, format, args);
+    int len = vsnprintf(vprintf_buffer, sizeof(vprintf_buffer), format, args);
     if (len > 0) {
+        if (len > (sizeof(vprintf_buffer) - 1)) {
+            int trunc_b = len - (sizeof(vprintf_buffer) - 1);
+            log_router_debug_printf("Buffer too small, lost %d bytes\n", trunc_b);
+            len = sizeof(vprintf_buffer) - 1;
+        }
+
         vprintf_buffer[len] = '\0';
         uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
 


### PR DESCRIPTION
## Description

The return value of vsnprintf() is used to determine how long the message was. However, when vsprintf() truncates a message this value will exceed the buffer! Then, vprintf_buffer[len] = '\0'; will cause undefined behaviour.

Add a check for truncation, which will then set the value of `len`  to match the number of bytes in the buffer

Also removed the -1 from the 'size' argument to vsnprintf(), because it already accounts for the terminating '\0' byte.

## Testing
I discovered this because my program would always crash after a particular log message. The stack trace showed that something was corrupting the `g_esp_log_router_vprintf` function pointer and cause any subsequent log messages to panic. Using the ESP32-S3 on-chip debugger I could put a watchpoint on  `g_esp_log_router_vprintf`and thus detect when it was changed by `vprintf_buffer[len] = '\0';`

After fixing the problem, the program no longer crashes after that message, or other long messages.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
