### PR TITLE
overhaul!(log_router): Properly handle buffer timeout, and defer file I/O to background task.

### DIFF
--- a/components/utilities/log_router/CHANGELOG.md
+++ b/components/utilities/log_router/CHANGELOG.md
@@ -1,5 +1,26 @@
 # ChangeLog
 
+## v0.3.0 - 2026-06-12
+
+### Enhancement ###
+
+* Move all file I/O into a background task, using a ringbuffer.
+* Flush all buffers and fsync() files when esp-restart() is called.
+* Handle read errors in esp_log_router_dump_file_messages()
+* KConfig options to disable the ringbuffer, the per-file batch-buffers, or both.
+* KConfig options to allocate batch-buffers and/or ringbuffer in PSRAM.
+* KConfig option to statically-allocate ringbuffer.
+
+### Feature ###
+* new functions: esp_log_router_status_file(), esp_log_router_sync_file
+* esp_log_router_dump_file_messages() now returns ESP_ERR_NOT_FOUND instead of ESP_OK if the file is not currently a log target.
+
+### Bug fix ###
+
+* Fix buffer timeout flush being delayed until the next call to a log function.
+* Fix esp_log_router_dump_file_messages() splitting lines longer than its buffer.
+* Fix esp_log_router_dump_file_messages() not printing recent messages.
+
 ## v0.2.0 - 2026-05-15
 
 ### Feature ###

--- a/components/utilities/log_router/CHANGELOG.md
+++ b/components/utilities/log_router/CHANGELOG.md
@@ -1,6 +1,10 @@
 # ChangeLog
 
-## v0.1.2 - 2026-05-15
+## v0.2.0 - 2026-05-15
+
+### Feature ###
+
+* Append an indicator string to truncated messages
 
 ### Bug fix ###
 

--- a/components/utilities/log_router/CMakeLists.txt
+++ b/components/utilities/log_router/CMakeLists.txt
@@ -1,6 +1,7 @@
 idf_component_register(SRC_DIRS "."
                         INCLUDE_DIRS "include"
-                        REQUIRES "fatfs" "esp_timer")
+                        PRIV_INCLUDE_DIRS "priv_include"
+                        REQUIRES "fatfs" "esp_timer" "esp_ringbuf")
 
 include(package_manager)
 cu_pkg_define_version(${CMAKE_CURRENT_LIST_DIR})

--- a/components/utilities/log_router/Kconfig
+++ b/components/utilities/log_router/Kconfig
@@ -36,6 +36,29 @@ menu "LOG ROUTER"
             Larger buffer can handle longer log messages but uses more stack space.
             Range: 256 to 1024 bytes
 
+    config LOG_ROUTER_APPEND_STRING_ON_TRUNCATE
+        bool "Show message on truncate"
+        default y
+        help
+            When enabled, log messages that are truncated because they do not fit
+            into LOG_ROUTER_FORMAT_BUFFER_SIZE will have a string appended to them,
+            to indicate that the log message is incomplete.
+
+    if LOG_ROUTER_APPEND_STRING_ON_TRUNCATE
+		config LOG_ROUTER_TRUNCATE_STRING
+			string
+			default "<TRUNCATED>"
+			prompt "Append this string to truncated logs"
+			help
+				String appended to truncated log messages. If log colors are enabled,
+				it will be formatted as purple italics: see CONFIG_LOG_COLORS
+
+				A newline character is also added, so that the next log message starts
+				on its own line.
+
+
+	endif #LOG_ROUTER_APPEND_STRING_ON_TRUNCATE
+
     config LOG_ROUTER_DEBUG_OUTPUT
         bool "Enable debug output"
         default y

--- a/components/utilities/log_router/Kconfig
+++ b/components/utilities/log_router/Kconfig
@@ -1,40 +1,203 @@
-menu "LOG ROUTER"
+menu "Log router"
 
-    config LOG_ROUTER_BUFFER_SIZE
-        int "Buffer size (bytes)"
-        range 2048 10240
-        default 4096
-        help
-            Size of the buffer used for log buffering.
-            Larger buffer reduces flash write frequency but uses more RAM.
-            Range: 2KB (2048) to 10KB (10240)
+	menu "Background task"
 
-    config LOG_ROUTER_FLUSH_THRESHOLD_PERCENT
-        int "Flush threshold percentage"
-        range 50 90
-        default 75
-        help
-            Percentage of buffer size at which to trigger a flush.
-            Higher percentage means more data buffered before writing to flash.
-            Range: 50% to 90%
+	    config LOG_ROUTER_TASK_NAME
+	        string "log_router task name"
+	        default "log_router"
+	        help
+	            Sets the log_router task's name.
 
-    config LOG_ROUTER_FLUSH_TIMEOUT_MS
-        int "Flush timeout (milliseconds)"
-        range 2000 10000
-        default 2000
-        help
-            Maximum time to wait before flushing buffer to flash.
-            Shorter timeout ensures more frequent writes but may reduce performance.
-            Range: 2 seconds (2000ms) to 10 seconds (10000ms)
+	     choice LOG_ROUTER_TASK_CORE_AFFINITY
+	     	prompt "log_router task core affinity"
+	        default LOG_ROUTER_TASK_NO_AFFINITY
+	        help
+	            Sets the log_router task's core affinity
 
-    config LOG_ROUTER_FORMAT_BUFFER_SIZE
-        int "Log format buffer size (bytes)"
-        range 256 1024
-        default 256
+	        config LOG_ROUTER_TASK_AFFINITY_CPU0
+	            bool "CPU0"
+	        config LOG_ROUTER_TASK_AFFINITY_CPU1
+	            bool "CPU1"
+	            depends on !FREERTOS_UNICORE
+	        config LOG_ROUTER_TASK_NO_AFFINITY
+	            bool "No affinity"
+	    endchoice
+
+	    config LOG_ROUTER_TASK_CORE_AFFINITY
+	        hex
+	        default 0x0 if LOG_ROUTER_TASK_AFFINITY_CPU0
+	        default 0x1 if LOG_ROUTER_TASK_AFFINITY_CPU1
+	        default FREERTOS_NO_AFFINITY if FREERTOS_TIMER_TASK_NO_AFFINITY
+
+	    config LOG_ROUTER_TASK_PRIORITY
+	        int "log_router task priority"
+	        range 1 25
+	        default 1
+	        depends on FREERTOS_USE_TIMERS
+	        help
+	            Sets the log_router task's priority.
+
+	    config LOG_ROUTER_TASK_STACK_DEPTH
+	        int "log_router task stack depth"
+	        range 1536 32768
+	        default 3840
+	        help
+	            Set the log_router task's stack size.
+
+	endmenu
+
+	menu "Ringbuffer"
+
+
+		config LOG_ROUTER_RINGBUFFER
+	    	bool "Defer log writing to background task"
+	    	default y
+	    	help
+	    		Reduce logging latency by writing into a ring-buffer and processing
+	    		them in the background when there is nothing else to do. This allows
+	    		the task doing the logging to continue immediately after formatting
+	    		the message, without having to do any expensive string parsing,
+	    		copying, or writing to files.
+
+	    if LOG_ROUTER_RINGBUFFER
+
+			config LOG_ROUTER_RINGBUFFER_SIZE
+		    	int "Ring-buffer size (bytes)"
+		        range 2048 32768
+		        default 16384
+		        help
+		            Size of the ringbuffer used to defer writing logs to background task.
+		            If too many messages are written without an opportunity for task to
+		            run, the buffer will fill up, and the tasks logging ESP_LOG will
+		            be forced to write out some of the older logs before it can continue.
+		            Range: 2KB (2048) to 16KB (16384)
+
+	        config LOG_ROUTER_RINGBUFFER_STATIC
+		        bool "Static allocate ringbuffer memory"
+		        default n
+		        help
+		            When this option is enabled, the ringbuffer will be allocated in static memory.
+					The size of LOG_ROUTER_RINGBUFFER_SIZE must be a multiple of 4 (32-bit aligned)
+					or else the application will crash.
+
+	        config LOG_ROUTER_RINGBUFFER_IN_EXT
+		        bool "Allocate ringbuffer in external RAM"
+		        default n
+		        depends on SPIRAM
+		        depends on 	(!LOG_ROUTER_RINGBUFFER_STATIC && (SPIRAM_USE_CAPS_ALLOC || SPIRAM_USE_MALLOC)) \
+		        		||	(LOG_ROUTER_RINGBUFFER_STATIC && SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY)
+		        help
+					When this option is enabled, the ringbuffer will be allocated in external RAM.
+					It is recommended to keep this option off, as it will reduce the speed of calls to
+					ESP_LOG functions.
+
+	    endif #LOG_ROUTER_RINGBUFFER
+
+	    if !LOG_ROUTER_RINGBUFFER
+
+		    config LOG_ROUTER_FORMAT_BUFFER_SIZE
+		        int "Log format buffer size (bytes)"
+		        range 256 2048
+		        default 256
+		        help
+		            Size of the buffer used for formatting log messages in log_router.
+		            A larger buffer can handle longer messages without truncating, at
+		            the cost of using more static memory.
+
+		            Not required when the ringbuffer is enabled - the ringbuffer's
+		            memory is used for formatting the message.
+
+		            Range: 256 to 2048 bytes
+
+	    endif #!LOG_ROUTER_RINGBUFFER
+
+	endmenu
+
+	menu "Batch write buffers"
+
+	    config LOG_ROUTER_BATCH_WRITE_BUFFER
+	    	bool "Batch writes to each log file"
+	    	default y
+	    	help
+	    		Reduce the frequency of flash operations by writing messages in batches.
+	    		Messages will a per-file buffer until there is no more space, then the
+	    		whole buffer will be written at once. Buffers will also be flushed after
+	    		a certain amount of time has passed.
+
+	    if LOG_ROUTER_BATCH_WRITE_BUFFER
+
+		    config LOG_ROUTER_BUFFER_SIZE
+		        int "Buffer size (bytes)"
+		        range 2048 10240
+		        default 4096
+		        help
+		            Size of the buffer used to batch writes to each file.
+		            Larger buffer reduces flash write frequency but uses more RAM.
+		            Range: 2KB (2048) to 10KB (10240)
+
+	        config LOG_ROUTER_BATCH_BUFFER_PREFER_EXT_RAM
+		        bool "Allocate per-file batch buffer in external RAM"
+		        default y
+		        depends on SPIRAM
+		        depends on SPIRAM_USE_CAPS_ALLOC || SPIRAM_USE_MALLOC
+		        help
+		            When this option is enabled, the per-file batch buffers will be allocated
+					from external RAM. If the allocation from external RAM fails, the buffer
+					will be allocated from internal RAM.
+					External RAM is slower, but this is not a problem when the ringbuffer
+					is enabled as operations using it are performed in a background task, and
+					do not affect the speed of ESP_LOG functions.
+
+		    config LOG_ROUTER_FLUSH_TIMEOUT_MS
+		        int "Batch buffer flush timeout (milliseconds)"
+		        range 2000 60000
+		        default 10000
+		        help
+		            Maximum time to wait before flushing a partially-filled buffer to flash,
+		            measured from the oldest data in the buffer.
+		            A shorter timeout can reduce the risk of losing data due to crash or
+		            power-loss, at the cost of more frequent writes to flash.
+		            Range: 2 seconds (2000ms) to 60 seconds (60000ms)
+
+		    config LOG_ROUTER_FLUSH_TIMEOUT_HYSTERESIS_MS
+		        int "Group together batch buffer flush (milliseconds)"
+		        range 0 LOG_ROUTER_FLUSH_TIMEOUT_MS
+		        default 50
+		        help
+		            When flushing a buffer, flush other buffers as well if their timeout will
+		            occur within the set period. This reduces the amount of work the log_router
+		            task needs to do, especially when the log_router is writing the same
+		            messages to multiple files at once.
+		            Range: less than the flush timeout period
+
+
+	    endif #LOG_ROUTER_BATCH_WRITE_BUFFER
+
+	endmenu
+
+    config LOG_ROUTER_FLUSH_BUFFERS_ON_RESTART
+    depends on LOG_ROUTER_RINGBUFFER || LOG_ROUTER_BATCH_WRITE_BUFFER
+    bool "Flush buffers when esp_restart() is called"
+    default y
+    help
+        Register a shutdown handler to ensure that messages in the ring-buffer
+        and batch-buffer are flushed to disk before restarting the esp32, when
+        esp_restart() is called.
+        Calls to ESP_LOG functions after esp_restart(), but if they do, they
+        are guaranteed to be whole.
+        It is not recommended to turn this option off.
+
+    config LOG_ROUTER_SHUTDOWN_HANDLER_TIMEOUT_MS
+        int "Shutdown handler timeout (milliseconds)"
+        range 0 20000
+        default 1000
+        depends on LOG_ROUTER_FLUSH_BUFFERS_ON_RESTART
         help
-            Size of the buffer used for formatting log messages in log_router.
-            Larger buffer can handle longer log messages but uses more stack space.
-            Range: 256 to 1024 bytes
+            If another task got stuck while writing messages to a file, it could cause the
+            shutdown handler to wait forever for the mutex. This timeout makes sure that
+            if that happened, it will panic and reboot (without flushing any files).
+            Range: up to 20 seconds (20000ms)
+
 
     config LOG_ROUTER_APPEND_STRING_ON_TRUNCATE
         bool "Show message on truncate"
@@ -45,6 +208,7 @@ menu "LOG ROUTER"
             to indicate that the log message is incomplete.
 
     if LOG_ROUTER_APPEND_STRING_ON_TRUNCATE
+
 		config LOG_ROUTER_TRUNCATE_STRING
 			string
 			default "<TRUNCATED>"

--- a/components/utilities/log_router/idf_component.yml
+++ b/components/utilities/log_router/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.2"
+version: "0.2.0"
 description: LogRouter redirects and filters ESP logs to various storage media
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/utilities/log_router
 repository: https://github.com/espressif/esp-iot-solution.git

--- a/components/utilities/log_router/idf_component.yml
+++ b/components/utilities/log_router/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.3.0"
 description: LogRouter redirects and filters ESP logs to various storage media
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/utilities/log_router
 repository: https://github.com/espressif/esp-iot-solution.git

--- a/components/utilities/log_router/include/log_router.h
+++ b/components/utilities/log_router/include/log_router.h
@@ -1,9 +1,13 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <sys/stat.h>
 
 #include "esp_err.h"
 #include "esp_log.h"
@@ -20,8 +24,13 @@ extern "C" {
  * specified level will be written to the file. If a tag is specified, only messages
  * from that specific tag will be captured.
  *
- * The log router uses buffered writing for better performance and automatically
- * flushes the buffer when it reaches the threshold or timeout.
+ * The log router uses an intermediate ring-buffer to reduce the latency of calls to
+ * ESP_LOG() functions. A background task flushes the buffer when the CPU has nothing
+ * more important to do. The size of the buffer is set by KConfig options.
+ *
+ * The log_router also uses a buffer to batch together writes to each log file. This
+ * can substantially reduce the number of flash operations. The size of the buffer,
+ * and the time-out period is set by KConfig options.
  *
  * @param file_path Path to the log file where messages will be written
  * @param tag Tag filter for log messages. If NULL, captures all messages that meet the level requirement
@@ -48,34 +57,77 @@ esp_err_t esp_log_router_to_file(const char* file_path, const char* tag, esp_log
 void esp_log_router_to_console(bool output_console);
 
 /**
- * @brief Dump the contents of a log file to console
+ * @brief Stop routing logs to a file.
  *
- * This function reads and displays the entire contents of a log file to the console.
- * Useful for debugging and viewing log file contents without external tools.
+ * Stop routing logs to the specified file. All pending messages destined to this file
+ * will be written before closing the file. The file is not deleted.
  *
- * @param file_path Path to the log file to dump
- *
- * @return
- *      - ESP_OK: File dumped successfully
- *      - ESP_ERR_INVALID_ARG: Invalid file path
- *      - ESP_FAIL: Failed to open or read file
- */
-esp_err_t esp_log_router_dump_file_messages(const char* file_path);
-
-/**
- * @brief Delete a log router and close its associated file
- *
- * This function removes a log router from the system and closes its associated
- * log file. The file itself is not deleted from the filesystem.
- *
- * @param file_path Path to the log file whose router should be deleted
+ * @param file_path Path to the log file registered with \c esp_log_router_to_file()
  *
  * @return
  *      - ESP_OK: Log router deleted successfully
  *      - ESP_ERR_INVALID_ARG: Invalid file path
  *      - ESP_ERR_NOT_FOUND: No log router found for the specified file path
  */
-esp_err_t esp_log_delete_router(const char* file_path);
+esp_err_t esp_log_router_stop_file(const char* file_path);
+
+__attribute__((deprecated))
+static inline esp_err_t esp_log_delete_router(const char* file_path)
+{
+    return esp_log_router_stop_file(file_path);
+}
+
+/**
+ * @brief Check if a file is being used for logging
+ *
+ * @param [in]  file_path   Path to the log file
+ *
+ * @return
+ *      - ESP_OK: File is currently a log target.
+ *      - ESP_ERR_INVALID_ARG: Invalid file path
+ *      - ESP_ERR_NOT_FOUND: File is not currently being used for logging
+ */
+esp_err_t esp_log_router_status_file(const char* file_path);
+
+/**
+ * @brief Flush all pending messages to a given logfile
+ *
+ * Ensures that all pending messages destined to this file have been processed,
+ * and flushes associated buffers to disk before returning.
+ *
+ * An optional \p sbuf argument can be used to get the file size immediately after
+ * sync has finished, before other tasks have an opportunity to add to it. All
+ * messages up to that point in the file are guaranteed to be fully-written.
+ *
+ * @param [in]  file_path   Path to the log file to sync
+ * @param [out] sbuf        Result of fstat() immediately after sync.
+ *
+ * @return
+ *      - ESP_OK: Sync success
+ *      - ESP_ERR_NOT_FOUND: File is not currently being used for logging
+ *      - ESP_ERR_INVALID_ARG: Invalid file path
+ *      - ESP_FAIL: Failed to fstat() the file
+ */
+esp_err_t esp_log_router_sync_file(const char* file_path, struct stat *sbuf);
+
+/**
+ * @brief Dump the contents of a log file to console
+ *
+ * This function will first flush buffers, ensuring that any in-flight logs intended
+ * for \p file_path have been written to the file.
+ *
+ * Messages that arrive after that point will not be dumped; this prevents partially-written
+ * message fragments from ending up in the output.
+ *
+ * @param file_path Path to the log file to dump
+ *
+ * @return
+ *      - ESP_OK: File dumped successfully
+ *      - ESP_ERR_NOT_FOUND: File dumped successfully, even though it is not currently a log target
+ *      - ESP_ERR_INVALID_ARG: Invalid file path
+ *      - ESP_FAIL: Failed to open or read file
+ */
+esp_err_t esp_log_router_dump_file_messages(const char* file_path);
 
 #ifdef __cplusplus
 }

--- a/components/utilities/log_router/log_router.c
+++ b/components/utilities/log_router/log_router.c
@@ -15,9 +15,20 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "log_router.h"
+#include "esp_log_color.h"
+
+#include "sdkconfig.h"
 
 static const char *TAG = "log_router";
 
+// Truncated messages will be immediately followed by this message
+#if (CONFIG_LOG_ROUTER_APPEND_STRING_ON_TRUNCATE)
+#if (CONFIG_LOG_COLORS)
+static const char *TRUNCATE_MESSAGE = LOG_ITALIC(LOG_COLOR_PURPLE) "" CONFIG_LOG_ROUTER_TRUNCATE_STRING "" LOG_RESET_COLOR "\n" ;
+#else
+static const char *TRUNCATE_MESSAGE = CONFIG_LOG_ROUTER_TRUNCATE_STRING "\n" ;
+#endif
+#endif
 // Global mutex for thread safety
 static SemaphoreHandle_t g_log_router_mutex = NULL;
 
@@ -93,6 +104,96 @@ static esp_err_t esp_log_router_flush_buffer(esp_log_router_slist_t *item)
     return ESP_OK;
 }
 
+static void router_fwrite(const void *__restrict buffer, size_t size, size_t n, esp_log_router_slist_t *item, uint32_t now)
+{
+    bool should_flush = false;
+
+    size_t len = n * size;
+
+    // Check if we need to flush due to threshold
+    if ((item->buffer_pos + len) >= item->flush_threshold) {
+        should_flush = true;
+        log_router_debug_printf("Flush buffer due to threshold\n");
+    }
+
+    // Check if we need to flush due to timeout
+    if ((now - item->last_flush_time) >= item->flush_timeout_ms) {
+        should_flush = true;
+        log_router_debug_printf("Flush buffer due to timeout\n");
+    }
+
+    // Flush buffer if needed
+    if (should_flush) {
+#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
+        uint64_t flush_start_time = esp_timer_get_time();
+#endif
+        esp_err_t flush_ret = esp_log_router_flush_buffer(item);
+#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
+        uint32_t flush_duration_us = esp_timer_get_time() - flush_start_time;
+        log_router_debug_printf("Flush operation took %ums, file: %s\n", flush_duration_us / 1000, item->file_path);
+#endif
+        if (flush_ret != ESP_OK) {
+            log_router_debug_printf("Failed to flush buffer: %s\n", esp_err_to_name(flush_ret));
+            // Flush failed, write directly to file
+            size_t written = fwrite(buffer, 1, len, item->log_fp);
+            if (written != len) {
+                log_router_debug_printf("Failed to write directly to file, written: %zu, expected: %d\n", written, len);
+                // Try to seek to beginning and retry
+                if (fseek(item->log_fp, 0, SEEK_SET) == 0 && ftruncate(fileno(item->log_fp), 0) == 0) {
+                    log_router_debug_printf("File truncated, retrying direct write\n");
+                    written = fwrite(buffer, 1, len, item->log_fp);
+                    if (written != len) {
+                        log_router_debug_printf("Retry direct write also failed\n");
+                        return;
+                    }
+                } else {
+                    log_router_debug_printf("Failed to seek/truncate file for direct write\n");
+                    return;
+                }
+            }
+            fflush(item->log_fp);
+            fsync(fileno(item->log_fp));
+            return; // Skip buffer write since we already wrote to file
+        }
+        // Flush successful, buffer is now empty, continue to buffer write
+    }
+
+    // Try to add to buffer, if still too large, write directly to file
+    if ((item->buffer_pos + len) < item->buffer_size) {
+        memcpy(item->buffer + item->buffer_pos, buffer, len);
+        item->buffer_pos += len;
+    } else {
+        // Buffer is too small, write directly to file
+#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
+        uint64_t write_start_time = esp_timer_get_time();
+#endif
+        size_t written = fwrite(buffer, 1, len, item->log_fp);
+        if (written != len) {
+            log_router_debug_printf("Failed to write directly to file, written: %zu, expected: %d\n", written, len);
+            // Try to seek to beginning and retry
+            if (fseek(item->log_fp, 0, SEEK_SET) == 0 && ftruncate(fileno(item->log_fp), 0) == 0) {
+                log_router_debug_printf("File truncated, retrying direct write\n");
+                written = fwrite(buffer, 1, len, item->log_fp);
+                if (written != len) {
+                    log_router_debug_printf("Retry direct write also failed\n");
+                    return;
+                }
+            } else {
+                log_router_debug_printf("Failed to seek/truncate file for direct write\n");
+                return;
+            }
+        }
+        fflush(item->log_fp);
+        fsync(fileno(item->log_fp));
+#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
+        uint32_t write_duration_us = esp_timer_get_time() - write_start_time;
+        log_router_debug_printf("Direct write took %ums, size: %d, file: %s\n", write_duration_us / 1000, len, item->file_path);
+#endif
+    }
+
+    return;
+}
+
 int esp_log_router_flash_vprintf(const char *format, va_list args)
 {
     int ret = 0;
@@ -124,8 +225,9 @@ int esp_log_router_flash_vprintf(const char *format, va_list args)
     esp_log_router_slist_t *item;
     int len = vsnprintf(vprintf_buffer, sizeof(vprintf_buffer), format, args);
     if (len > 0) {
+        int trunc_b = 0;
         if (len > (sizeof(vprintf_buffer) - 1)) {
-            int trunc_b = len - (sizeof(vprintf_buffer) - 1);
+            trunc_b = len - (sizeof(vprintf_buffer) - 1);
             log_router_debug_printf("Buffer too small, lost %d bytes\n", trunc_b);
             len = sizeof(vprintf_buffer) - 1;
         }
@@ -161,88 +263,13 @@ int esp_log_router_flash_vprintf(const char *format, va_list args)
             bool tag_match = (item->tag == NULL) || (tag_len > 0 && strncmp(tag_start, item->tag, tag_len) == 0 && item->tag[tag_len] == '\0');
 
             if (level_match && tag_match && item->log_fp) {
-                bool should_flush = false;
+                router_fwrite(vprintf_buffer, 1, len, item, now);
 
-                // Check if we need to flush due to threshold
-                if ((item->buffer_pos + len) >= item->flush_threshold) {
-                    should_flush = true;
-                    log_router_debug_printf("Flush buffer due to threshold\n");
+#if (CONFIG_LOG_ROUTER_APPEND_STRING_ON_TRUNCATE)
+                if (trunc_b > 0) {
+                    router_fwrite(TRUNCATE_MESSAGE, 1, strlen(TRUNCATE_MESSAGE), item, now);
                 }
-
-                // Check if we need to flush due to timeout
-                if ((now - item->last_flush_time) >= item->flush_timeout_ms) {
-                    should_flush = true;
-                    log_router_debug_printf("Flush buffer due to timeout\n");
-                }
-
-                // Flush buffer if needed
-                if (should_flush) {
-#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
-                    uint64_t flush_start_time = esp_timer_get_time();
 #endif
-                    esp_err_t flush_ret = esp_log_router_flush_buffer(item);
-#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
-                    uint32_t flush_duration_us = esp_timer_get_time() - flush_start_time;
-                    log_router_debug_printf("Flush operation took %ums, file: %s\n", flush_duration_us / 1000, item->file_path);
-#endif
-                    if (flush_ret != ESP_OK) {
-                        log_router_debug_printf("Failed to flush buffer: %s\n", esp_err_to_name(flush_ret));
-                        // Flush failed, write directly to file
-                        size_t written = fwrite(vprintf_buffer, 1, len, item->log_fp);
-                        if (written != len) {
-                            log_router_debug_printf("Failed to write directly to file, written: %zu, expected: %d\n", written, len);
-                            // Try to seek to beginning and retry
-                            if (fseek(item->log_fp, 0, SEEK_SET) == 0 && ftruncate(fileno(item->log_fp), 0) == 0) {
-                                log_router_debug_printf("File truncated, retrying direct write\n");
-                                written = fwrite(vprintf_buffer, 1, len, item->log_fp);
-                                if (written != len) {
-                                    log_router_debug_printf("Retry direct write also failed\n");
-                                    continue;
-                                }
-                            } else {
-                                log_router_debug_printf("Failed to seek/truncate file for direct write\n");
-                                continue;
-                            }
-                        }
-                        fflush(item->log_fp);
-                        fsync(fileno(item->log_fp));
-                        continue; // Skip buffer write since we already wrote to file
-                    }
-                    // Flush successful, buffer is now empty, continue to buffer write
-                }
-
-                // Try to add to buffer, if still too large, write directly to file
-                if ((item->buffer_pos + len) < item->buffer_size) {
-                    memcpy(item->buffer + item->buffer_pos, vprintf_buffer, len);
-                    item->buffer_pos += len;
-                } else {
-                    // Buffer is too small, write directly to file
-#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
-                    uint64_t write_start_time = esp_timer_get_time();
-#endif
-                    size_t written = fwrite(vprintf_buffer, 1, len, item->log_fp);
-                    if (written != len) {
-                        log_router_debug_printf("Failed to write directly to file, written: %zu, expected: %d\n", written, len);
-                        // Try to seek to beginning and retry
-                        if (fseek(item->log_fp, 0, SEEK_SET) == 0 && ftruncate(fileno(item->log_fp), 0) == 0) {
-                            log_router_debug_printf("File truncated, retrying direct write\n");
-                            written = fwrite(vprintf_buffer, 1, len, item->log_fp);
-                            if (written != len) {
-                                log_router_debug_printf("Retry direct write also failed\n");
-                                continue;
-                            }
-                        } else {
-                            log_router_debug_printf("Failed to seek/truncate file for direct write\n");
-                            continue;
-                        }
-                    }
-                    fflush(item->log_fp);
-                    fsync(fileno(item->log_fp));
-#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
-                    uint32_t write_duration_us = esp_timer_get_time() - write_start_time;
-                    log_router_debug_printf("Direct write took %ums, size: %d, file: %s\n", write_duration_us / 1000, len, item->file_path);
-#endif
-                }
             }
         }
     }

--- a/components/utilities/log_router/log_router.c
+++ b/components/utilities/log_router/log_router.c
@@ -3,21 +3,36 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "log_router.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stdatomic.h>
+#include <errno.h>
 #include <inttypes.h>
+#include <sys/cdefs.h>
 #include <sys/queue.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "esp_check.h"
+#include "esp_err.h"
+#include "esp_log_level.h"
 #include "esp_vfs_fat.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/projdefs.h"
 #include "freertos/semphr.h"
-#include "log_router.h"
+#include "freertos/timers.h"
+#include "freertos/ringbuf.h"
 #include "esp_log_color.h"
 
+#include "portmacro.h"
 #include "sdkconfig.h"
+#include "tlsf_control_functions.h"
+#include "xtensa_context.h"
+
+#include "log_router_macros.h"
 
 static const char *TAG = "log_router";
 
@@ -29,8 +44,39 @@ static const char *TRUNCATE_MESSAGE = LOG_ITALIC(LOG_COLOR_PURPLE) "" CONFIG_LOG
 static const char *TRUNCATE_MESSAGE = CONFIG_LOG_ROUTER_TRUNCATE_STRING "\n" ;
 #endif
 #endif
-// Global mutex for thread safety
-static SemaphoreHandle_t g_log_router_mutex = NULL;
+
+// ---------------------------- //
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+//! Message buffer. Thread-safe.
+//! @note A slice of bytes can be reserved in advance with xRingbufferSendAcquire(), and used instead of a formatting buffer
+static RingbufHandle_t g_ringbuf = NULL;
+#else
+//! Formatting buffer. Not thread-safe.
+static char vprintf_buffer[CONFIG_LOG_ROUTER_FORMAT_BUFFER_SIZE];
+#endif
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER && CONFIG_LOG_ROUTER_RINGBUFFER_STATIC)
+#if (LOG_ROUTER_RINGBUFFER_IN_EXT)
+EXT_RAM_ATTR static uint8_t ringbufferStorage[CONFIG_LOG_ROUTER_RINGBUFFER_SIZE];
+EXT_RAM_ATTR static StaticRingbuffer_t staticRingbuffer;
+#else
+static uint8_t ringbufferStorage[CONFIG_LOG_ROUTER_RINGBUFFER_SIZE];
+static StaticRingbuffer_t staticRingbuffer;
+#endif
+#endif
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+//! Global mutex ensuring messages are printed in the same order they enter the ringbuffer
+//! Otherwise, messages could be re-ordered while draining the ringbuffer, due to a race-condition
+//! However, the race is over a small and simple but of code, so it's unlikely that it would happen in practice
+static SemaphoreHandle_t g_ringbuf_drain_mutex = NULL;
+#endif
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER || CONFIG_LOG_ROUTER_BATCH_WRITE_BUFFER)
+//! Low-priority task used to (1) Drain the ringbuffer and/or (2) flush buffers after a timeout period
+static TaskHandle_t g_log_router_drain_task = NULL;
+#endif
 
 // Custom debug output function
 static void log_router_debug_printf(const char *format, ...)
@@ -44,15 +90,27 @@ static void log_router_debug_printf(const char *format, ...)
 #endif
 }
 
+//! Global mutex that protects the linked list.
+//! Any operation that traverses the list, or uses any of its items, must lock the mutex
+//! until it is completely finished.
+static SemaphoreHandle_t g_slist_mutex = NULL;
+
+//! Used to mark functions that expect the mutex to be locked
+static bool MUTEX_LOCKED(SemaphoreHandle_t mut)
+{
+    return xTaskGetCurrentTaskHandle() == xSemaphoreGetMutexHolder(mut);
+}
+
 typedef struct _esp_log_router_slist_t {
     char *file_path;                                               /*!< File path for log */
     char *tag;                                                     /*!< Tag for log */
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE)
     char *buffer;                                                  /*!< Buffer for log data */
     size_t buffer_size;                                            /*!< Buffer size for batch writing */
     size_t buffer_pos;                                             /*!< Current position in buffer */
-    size_t flush_threshold;                                        /*!< Flush threshold */
     uint32_t flush_timeout_ms;                                     /*!< Flush timeout in milliseconds */
-    uint32_t last_flush_time;                                      /*!< Last flush time */
+    uint32_t buffer_time_ms;                                       /*!< Oldest data in buffer. Ignored when (buffer_pos == 0) */
+#endif
     FILE *log_fp;
     esp_log_level_t level;
     SLIST_ENTRY(_esp_log_router_slist_t) next;
@@ -61,236 +119,588 @@ typedef struct _esp_log_router_slist_t {
 static SLIST_HEAD(_esp_log_router_head_t, _esp_log_router_slist_t) g_esp_log_router_slist_head = SLIST_HEAD_INITIALIZER(g_esp_log_router_slist_head);
 static bool g_esp_log_router_keep_console = true;                  /*!< Whether to keep console output */
 static vprintf_like_t g_esp_log_router_vprintf = NULL;             /*!< Original vprintf function */
-static char dump_log_buffer[CONFIG_LOG_ROUTER_FORMAT_BUFFER_SIZE]; /*!< Buffer for dump log messages */
-static char vprintf_buffer[CONFIG_LOG_ROUTER_FORMAT_BUFFER_SIZE];  /*!< Buffer for formatted log messages */
 
-static esp_err_t esp_log_router_flush_buffer(esp_log_router_slist_t *item)
+//! Highest log level currently in use, used to skip processing for messages that won't be written anyway
+//! Lock-free, because atomic is sufficient for correctness.
+static _Atomic(esp_log_level_t) g_level_max = 0;
+
+static esp_err_t router_write_direct(const void *__restrict buffer, size_t count, esp_log_router_slist_t *item)
 {
-    if (!item || !item->buffer || item->buffer_pos == 0 || !item->log_fp) {
-        return ESP_FAIL;
+    assert(MUTEX_LOCKED(g_slist_mutex));
+
+    FILE *fp = item->log_fp;
+
+    if (!fp) {
+        log_router_debug_printf("Failed to open file: %s", strerror(errno));
+        return ESP_ERR_NO_MEM;
     }
 
-    size_t written = fwrite(item->buffer, 1, item->buffer_pos, item->log_fp);
-    if (written != item->buffer_pos) {
-        log_router_debug_printf("Failed to write complete buffer to file, written: %zu, expected: %zu\n", written, item->buffer_pos);
-
-        // Try to seek to beginning of file and start over
-        if (fseek(item->log_fp, 0, SEEK_SET) == 0) {
-            log_router_debug_printf("Seeking to beginning of file due to write failure\n");
-            // Clear the file by truncating it
-            if (ftruncate(fileno(item->log_fp), 0) == 0) {
-                log_router_debug_printf("File truncated, retrying write\n");
-                // Retry the write
-                written = fwrite(item->buffer, 1, item->buffer_pos, item->log_fp);
-                if (written != item->buffer_pos) {
-                    log_router_debug_printf("Retry write also failed, written: %zu, expected: %zu\n", written, item->buffer_pos);
-                    return ESP_FAIL;
-                }
-            } else {
-                log_router_debug_printf("Failed to truncate file\n");
+    size_t written = fwrite(buffer, 1, count, fp);
+    if (written != count) {
+        log_router_debug_printf("Failed to write %d bytes to file '%s', returned: %zu\n", count, item->file_path, written);
+        // Try to seek to the beginning of the file and start fresh
+        if (fseek(fp, 0, SEEK_SET) == 0 && ftruncate(fileno(fp), 0) == 0) {
+            log_router_debug_printf("File truncated, retrying write\n");
+            written = fwrite(buffer, 1, count, fp);
+            if (written != count) {
+                log_router_debug_printf("Retry direct write also failed\n");
                 return ESP_FAIL;
             }
         } else {
-            log_router_debug_printf("Failed to seek to beginning of file\n");
+            log_router_debug_printf("Failed to seek/truncate file for direct write\n");
             return ESP_FAIL;
         }
     }
-
-    fflush(item->log_fp);
-    fsync(fileno(item->log_fp));
-    item->buffer_pos = 0;
-    item->last_flush_time = (uint32_t)(esp_timer_get_time() / 1000);
+    fflush(fp);
+    fsync(fileno(fp));  // Would sync() be more suitable here?
 
     return ESP_OK;
 }
 
-static void router_fwrite(const void *__restrict buffer, size_t size, size_t n, esp_log_router_slist_t *item, uint32_t now)
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE)
+
+static esp_err_t esp_log_router_flush_buffer(esp_log_router_slist_t *item)
 {
-    bool should_flush = false;
+    assert(MUTEX_LOCKED(g_slist_mutex));
 
-    size_t len = n * size;
-
-    // Check if we need to flush due to threshold
-    if ((item->buffer_pos + len) >= item->flush_threshold) {
-        should_flush = true;
-        log_router_debug_printf("Flush buffer due to threshold\n");
+    if (item->buffer_pos == 0) {
+        return ESP_OK;  // Nothing to do
     }
 
-    // Check if we need to flush due to timeout
-    if ((now - item->last_flush_time) >= item->flush_timeout_ms) {
-        should_flush = true;
-        log_router_debug_printf("Flush buffer due to timeout\n");
+    assert(item);
+    assert(item->buffer);
+
+    log_router_debug_printf("Flushing %d bytes to file: %s\n", item->buffer_pos, item->file_path);
+
+    LOG_ROUTER_DEBUG_TIMING_BEGIN();
+
+    ESP_ERROR_CHECK_WITHOUT_ABORT(router_write_direct(item->buffer, item->buffer_pos, item));
+
+    LOG_ROUTER_DEBUG_TIMING_END_MSG(, "Flushed %d bytes -> file: %s\n", item->buffer_pos, item->file_path);
+
+    item->buffer_pos = 0;
+    return ESP_OK;
+}
+
+#endif
+
+//! Write already-formatted message to buffer, flushing to the file if the buffer is full
+static void router_write_buffered(const void *__restrict buffer, size_t count, esp_log_router_slist_t *item)
+{
+    assert(MUTEX_LOCKED(g_slist_mutex));
+
+#if (!CONFIG_LOG_ROUTER_BATCH_WRITE)
+    LOG_ROUTER_DEBUG_TIMING_BEGIN();
+
+    router_write_direct(buffer, count, item);
+
+    LOG_ROUTER_DEBUG_TIMING_END_MSG(, "Direct write, size: %d, file: %s\n", count, item->file_path);
+
+    return;
+#else
+
+    // Record when the oldest data in the buffer was written, for time-out purposes
+    if (item->buffer_pos == 0) {
+        item->buffer_time_ms = (uint32_t)(esp_timer_get_time() / 1000);
     }
 
-    // Flush buffer if needed
-    if (should_flush) {
-#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
-        uint64_t flush_start_time = esp_timer_get_time();
-#endif
-        esp_err_t flush_ret = esp_log_router_flush_buffer(item);
-#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
-        uint32_t flush_duration_us = esp_timer_get_time() - flush_start_time;
-        log_router_debug_printf("Flush operation took %ums, file: %s\n", flush_duration_us / 1000, item->file_path);
-#endif
-        if (flush_ret != ESP_OK) {
-            log_router_debug_printf("Failed to flush buffer: %s\n", esp_err_to_name(flush_ret));
-            // Flush failed, write directly to file
-            size_t written = fwrite(buffer, 1, len, item->log_fp);
-            if (written != len) {
-                log_router_debug_printf("Failed to write directly to file, written: %zu, expected: %d\n", written, len);
-                // Try to seek to beginning and retry
-                if (fseek(item->log_fp, 0, SEEK_SET) == 0 && ftruncate(fileno(item->log_fp), 0) == 0) {
-                    log_router_debug_printf("File truncated, retrying direct write\n");
-                    written = fwrite(buffer, 1, len, item->log_fp);
-                    if (written != len) {
-                        log_router_debug_printf("Retry direct write also failed\n");
-                        return;
-                    }
-                } else {
-                    log_router_debug_printf("Failed to seek/truncate file for direct write\n");
-                    return;
-                }
-            }
-            fflush(item->log_fp);
-            fsync(fileno(item->log_fp));
-            return; // Skip buffer write since we already wrote to file
+    // Repeat until all bytes are buffered or written
+    size_t written = 0;
+    while (written < count) {
+        size_t todo = count - written;
+        size_t free_space = item->buffer_size - item->buffer_pos;
+
+        size_t min = MIN(todo, free_space);
+        memcpy(item->buffer + item->buffer_pos, buffer + written, min);
+        written += min;
+        item->buffer_pos += min;
+
+        assert(item->buffer_pos == item->buffer_size || count == written);
+
+        // Buffer full, flush and continue
+        if (item->buffer_pos == item->buffer_size) {
+            ESP_ERROR_CHECK_WITHOUT_ABORT(esp_log_router_flush_buffer(item));
         }
-        // Flush successful, buffer is now empty, continue to buffer write
-    }
-
-    // Try to add to buffer, if still too large, write directly to file
-    if ((item->buffer_pos + len) < item->buffer_size) {
-        memcpy(item->buffer + item->buffer_pos, buffer, len);
-        item->buffer_pos += len;
-    } else {
-        // Buffer is too small, write directly to file
-#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
-        uint64_t write_start_time = esp_timer_get_time();
-#endif
-        size_t written = fwrite(buffer, 1, len, item->log_fp);
-        if (written != len) {
-            log_router_debug_printf("Failed to write directly to file, written: %zu, expected: %d\n", written, len);
-            // Try to seek to beginning and retry
-            if (fseek(item->log_fp, 0, SEEK_SET) == 0 && ftruncate(fileno(item->log_fp), 0) == 0) {
-                log_router_debug_printf("File truncated, retrying direct write\n");
-                written = fwrite(buffer, 1, len, item->log_fp);
-                if (written != len) {
-                    log_router_debug_printf("Retry direct write also failed\n");
-                    return;
-                }
-            } else {
-                log_router_debug_printf("Failed to seek/truncate file for direct write\n");
-                return;
-            }
-        }
-        fflush(item->log_fp);
-        fsync(fileno(item->log_fp));
-#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
-        uint32_t write_duration_us = esp_timer_get_time() - write_start_time;
-        log_router_debug_printf("Direct write took %ums, size: %d, file: %s\n", write_duration_us / 1000, len, item->file_path);
-#endif
     }
 
     return;
+
+#endif
 }
+
+static esp_log_level_t char_to_level(const char level_char)
+{
+    switch (level_char) {
+    case 'E': return ESP_LOG_ERROR;
+    case 'W': return ESP_LOG_WARN;
+    case 'I': return ESP_LOG_INFO;
+    case 'D': return ESP_LOG_DEBUG;
+    case 'V': return ESP_LOG_VERBOSE;
+    default:  return ESP_LOG_NONE;
+    }
+}
+
+//! Write an already-formatted message to all files that match the log level and/or tag
+static esp_err_t router_fork_message(const char *__restrict buffer, size_t count)
+{
+    assert(MUTEX_LOCKED(g_slist_mutex));
+
+    const char *p = strchr(buffer, '(');
+    if (!p) {
+        ESP_ERROR_CHECK_WITHOUT_ABORT(ESP_ERR_INVALID_ARG); // Should have been checked before the message was formatted
+    }
+
+    char level_char = *(p - 2);
+    esp_log_level_t msg_level = char_to_level(level_char);
+
+    // Extract tag from formatted buffer (find the colon ':')
+    // If system time is printed, then we need to skip two more (see format string in esp_log_system_timestamp())
+    const char *colon_pos = strchr(buffer, ':');
+#ifdef CONFIG_LOG_TIMESTAMP_SOURCE_SYSTEM
+    colon_pos = colon_pos ? strchr(colon_pos, ':') : NULL;
+    colon_pos = colon_pos ? strchr(colon_pos, ':') : NULL;
+#endif
+    if (NULL == colon_pos) {
+        log_router_debug_printf("Not enough colons\n");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const char *tag_start = NULL;
+    size_t tag_len = 0;
+
+    if (colon_pos) {
+        // Find the start of tag (after the closing parenthesis)
+        tag_start = strchr(buffer, ')');
+        if (tag_start && tag_start < colon_pos) {
+            tag_start++; // Skip ')'
+            // Skip any spaces
+            while (tag_start < colon_pos && (*tag_start == ' ' || *tag_start == '\t')) {
+                tag_start++;
+            }
+            // Calculate tag length
+            tag_len = colon_pos - tag_start;
+            if (tag_len > 0) {
+                log_router_debug_printf("Extracted tag: '%.*s' (len=%zu)\n", (int)tag_len, tag_start, tag_len);
+            }
+        }
+    }
+
+    esp_log_router_slist_t *item;
+    SLIST_FOREACH(item, &g_esp_log_router_slist_head, next) {
+        // Check level and tag match
+        bool level_match = (msg_level <= item->level);
+        bool tag_match = (item->tag == NULL) || (tag_len > 0 && strncmp(tag_start, item->tag, tag_len) == 0 && item->tag[tag_len] == '\0');
+
+        if (level_match && tag_match) {
+            router_write_buffered(buffer, count, item);
+
+#if (CONFIG_LOG_ROUTER_APPEND_STRING_ON_TRUNCATE)
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+            size_t truncate_threshold = xRingbufferGetMaxItemSize(g_ringbuf);
+#else
+            size_t truncate_threshold = CONFIG_LOG_ROUTER_FORMAT_BUFFER_SIZE;
+#endif
+            truncate_threshold -= 1;    // Null-terminator wastes 1 byte of the buffer
+
+            if (count >= truncate_threshold) {
+                // Either it was truncated, or it was exactly the same length as the buffer.
+                router_write_buffered(TRUNCATE_MESSAGE, strlen(TRUNCATE_MESSAGE), item);
+            }
+#endif
+        }
+    }
+
+    return ESP_OK;
+}
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+
+static UBaseType_t rb_items_waiting()
+{
+    UBaseType_t items_waiting;
+    vRingbufferGetInfo(g_ringbuf, NULL, NULL, NULL, NULL, &items_waiting);
+    return items_waiting;
+}
+
+//! Thread-safe (waits for mutex)
+//! \param [out] b_count    Optional counter, incremented by number of bytes in message (not including null-terminator)
+static esp_err_t drain_one_from_ringbuffer(TickType_t xTicksToWait, size_t* b_count)
+{
+    // This prevents a potential race between two tasks from xRingbufferReceive() -> router_fork_message(), which
+    // could result in messages being printed out-of-order.
+    xSemaphoreTake(g_ringbuf_drain_mutex, portMAX_DELAY);
+
+    // Receive an item from no-split ring buffer (thread-safe). Does not copy data.
+    size_t rb_slice_size;
+    void* rb_slice = xRingbufferReceive(g_ringbuf, &rb_slice_size, xTicksToWait);
+    if (NULL == rb_slice) {
+        xSemaphoreGive(g_ringbuf_drain_mutex);
+        return ESP_ERR_TIMEOUT;
+    }
+    const char* rb_slice_pchar = (char*)rb_slice;
+
+    // Do not print NULL terminator
+    rb_slice_size -= 1;
+    assert(rb_slice_pchar[rb_slice_size] == '\0');
+
+    log_router_debug_printf("ringbuffer --> %d bytes (%d items waiting)\n", rb_slice_size, rb_items_waiting());
+
+    // Lock mutex while accessing the list
+    xSemaphoreTake(g_slist_mutex, portMAX_DELAY);
+
+    // Release the (potential) other task so it can get started reading from the ringbuffer.
+    assert(MUTEX_LOCKED(g_slist_mutex));    // We've locked writing, so the race-condition is over
+    xSemaphoreGive(g_ringbuf_drain_mutex);
+
+    esp_err_t err = router_fork_message(rb_slice_pchar, rb_slice_size);
+    if (err != ESP_OK) {
+        log_router_debug_printf("Invalid message: %.*s\n", rb_slice_size, rb_slice_pchar);
+    }
+
+    // Release mutex
+    xSemaphoreGive(g_slist_mutex);
+
+    // Return the item's memory to the ringbuffer.
+    vRingbufferReturnItem(g_ringbuf, rb_slice);
+
+    if (b_count != NULL) {
+        *b_count += rb_slice_size;
+    }
+
+    return ESP_OK;
+}
+
+/*! Drain all messages that are currently in the ringbuffer
+
+    Only attempts to drain the number of messages currently in the ringbuffer,
+    so it will always exit in finite time.
+
+    Messages that arrive after the  call to rb_items_waiting() may-or-may-not
+    be drained, because other tasks may call drain_one_from_ringbuffer() while
+    this function is working.
+
+    @param [out]    n_messages  Increments by 1 for each message successfully received
+    @param [out]    b_count     Incremented by number of bytes in received messages
+    @param [in]     yield_task  If true, calls \c vPortYield() after each message
+*/
+static esp_err_t drain_ringbuffer(bool yield_task)
+{
+    const size_t todo = rb_items_waiting(); // Only flush current messages
+
+    log_router_debug_printf("begin draining ringbuffer (%d messages)\n", todo);
+
+    LOG_ROUTER_DEBUG_TIMING_BEGIN();
+
+    size_t count = 0;
+    size_t b_count = 0;
+    for (int i = 0; i < todo; i++) {
+        esp_err_t err = drain_one_from_ringbuffer(0, &b_count);
+        if (ESP_ERR_TIMEOUT == err) {
+            // A higher-priority task preempted us and drained some messages
+            break;
+        }
+        ESP_RETURN_ON_ERROR(err, TAG, "");
+
+        count++;
+        if (yield_task) {
+            vPortYield();
+        }
+    }
+
+    LOG_ROUTER_DEBUG_TIMING_END_MSG(, "drained %d messages (totalling %d bytes)\n", count, b_count);
+    if (rb_items_waiting() > 0) {
+        log_router_debug_printf("%d new messages arrived while background task drained %d messages \n", rb_items_waiting(), count);
+    }
+
+    return ESP_OK;
+}
+
+//! Print a message straight into the ringbuffer (avoids redundant copies)
+//! If there's not enough space, flushes the oldest message(s) to make room.
+//! Thread-safe, but the order of messages may be different.
+static void vprintf_ringbuffer(const char *format, va_list args, size_t predicted_len)
+{
+    // Need a null-terminator - even though the ringbuffer records the size,
+    // vsnprintf() insists on adding a null-terminator, unfortunately.
+    size_t predicted_size = predicted_len + 1;
+
+    // We may have to truncate it, if the message is too large to fit into the ringbuffer
+    size_t rb_slice_size = MIN(predicted_size, xRingbufferGetMaxItemSize(g_ringbuf));
+    if (rb_slice_size < predicted_size) {
+        log_router_debug_printf("Message too long to fit in the ringbuffer, truncated %d bytes\n", (predicted_size - rb_slice_size));
+    }
+
+#ifdef CONFIG_LOG_ROUTER_DEBUG_OUTPUT
+    static size_t free_space_hwm = CONFIG_LOG_ROUTER_RINGBUFFER_SIZE;
+    size_t free_space = xRingbufferGetCurFreeSize(g_ringbuf);
+    free_space_hwm = MIN(free_space_hwm, free_space);
+
+    const size_t max_val_possible = xRingbufferGetMaxItemSize(g_ringbuf);
+    if (free_space >= max_val_possible) {
+        log_router_debug_printf("Ringbuffer free size >= %d bytes (hwm %d bytes)\n", max_val_possible, free_space_hwm);
+    } else {
+        log_router_debug_printf("Ringbuffer free size = %d bytes (hwm %d bytes)\n", free_space, free_space_hwm);
+    }
+
+    log_router_debug_printf("ringbuffer <-- %d bytes (%d items waiting)\n", rb_slice_size, rb_items_waiting());
+#endif
+
+    // Ask the ringbuffer for a slice of its bytes.
+    // If we've filled up the ringbuffer, we'll need to make room.
+    void* rb_slice;
+
+    LOG_ROUTER_DEBUG_TIMING_BEGIN();
+
+    size_t count = 0;
+    size_t b_count = 0;
+    while (true) {
+        BaseType_t success = xRingbufferSendAcquire(g_ringbuf, &rb_slice, rb_slice_size, 0);
+        if (pdTRUE == success) {
+            if (count > 0) {
+                LOG_ROUTER_DEBUG_TIMING_END();
+                log_router_debug_printf("ringbuffer OOM, drained %d messages (totalling %d bytes) in %ums \n", count, b_count, LOG_ROUTER_DEBUG_TIMING_RESULT() / 1000);
+            }
+            break;
+        }
+        // Flush some messages to make room in the buffer, then try again
+        esp_err_t err = drain_one_from_ringbuffer(0, &b_count);
+        if (err != ESP_OK) {
+            ; // This could theoretically happen if you had two VERY large messages and a race-condition with log_router_drain_task()
+        } else {
+            count++;
+        }
+    }
+    assert(rb_slice != NULL);
+
+    char* rb_slice_pchar = (char*)rb_slice;
+
+    // Format the message, directly into the bytes of the ringbuffer
+    int intended_size = vsnprintf(rb_slice_pchar, rb_slice_size, format, args) + 1;   // +1 for null-terminator
+    assert(intended_size == predicted_size);  // Behaviour is undefined if pointed-to args change during the call to a printf-like function
+
+    // Tell the ringbuffer that the message is ready
+    xRingbufferSendComplete(g_ringbuf, rb_slice);
+
+    return;
+}
+
+#endif
+
+#if (!CONFIG_LOG_ROUTER_RINGBUFFER)
+
+static void vprintf_no_ringbuffer(const char *format, va_list args, size_t predicted_len)
+{
+    // Lock mutex while accessing the list
+    xSemaphoreTake(g_slist_mutex, portMAX_DELAY);
+
+    int intended_len = vsnprintf(vprintf_buffer, CONFIG_LOG_ROUTER_FORMAT_BUFFER_SIZE, format, args);
+    assert(intended_len == predicted_len);  // Behaviour is undefined if pointed-to args change during the call to a printf-like function
+
+    int truncated_len = MIN(intended_len, (CONFIG_LOG_ROUTER_FORMAT_BUFFER_SIZE - 1));
+
+    esp_err_t err = router_fork_message(vprintf_buffer, truncated_len);
+    if (err != ESP_OK) {
+        log_router_debug_printf("Invalid message: %.*s\n", truncated_len, vprintf_buffer);
+    }
+
+    // Release mutex
+    xSemaphoreGive(g_slist_mutex);
+}
+
+#endif
+
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE)
+
+static uint32_t process_timeout(bool yield_task, uint32_t fuzziness_ms)
+{
+    uint32_t next_timeout = UINT32_MAX;
+    int count = 0;
+
+    // Lock mutex while accessing the list
+    xSemaphoreTake(g_slist_mutex, portMAX_DELAY);
+
+    uint32_t time = (uint32_t)(esp_timer_get_time() / 1000);
+
+    esp_log_router_slist_t *item;
+    SLIST_FOREACH(item, &g_esp_log_router_slist_head, next) {
+        uint32_t timeout = item->flush_timeout_ms;  // Shorter name
+        uint32_t age = time - item->buffer_time_ms; // overflow-correct
+        if (item->buffer_pos > 0) {
+            if ((age + fuzziness_ms) >= timeout) {
+                log_router_debug_printf("Timeout flush for file: '%s'\n", item->file_path);
+                ESP_ERROR_CHECK_WITHOUT_ABORT(esp_log_router_flush_buffer(item));
+                count += 1;
+            } else {
+                next_timeout = MIN(next_timeout, timeout - age);
+            }
+        }
+
+        // Ensure each buffer is check once per timeout period, as it is possible for writes to occur
+        // without waking the drain_task
+        next_timeout = MIN(next_timeout, timeout);
+
+        if (yield_task) {
+            vPortYield();
+        }
+    }
+
+    // Release mutex
+    xSemaphoreGive(g_slist_mutex);
+
+    log_router_debug_printf("Timeout flushed %d files\n", count);
+    log_router_debug_printf("Next timeout in %d ms\n", next_timeout);
+
+    return next_timeout;
+}
+
+#endif
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER || CONFIG_LOG_ROUTER_BATCH_WRITE)
+
+__attribute__((noreturn))
+static void log_router_drain_task(void *pvParameter)
+{
+    while (true) {
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE)
+        uint32_t next_check_delay_ms = process_timeout(true, CONFIG_LOG_ROUTER_FLUSH_TIMEOUT_HYSTERESIS_MS);
+#else
+        uint32_t next_check_delay_ms = portMAX_DELAY;
+#endif
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+        // Block until an item is available, then process it
+        log_router_debug_printf("Waiting %d ticks\n", pdMS_TO_TICKS(next_check_delay_ms));
+        esp_err_t err = drain_one_from_ringbuffer(pdMS_TO_TICKS(next_check_delay_ms), NULL);
+        if (err != ESP_ERR_TIMEOUT) {
+            ESP_ERROR_CHECK(err);   // Shouldn't fail
+        } else {
+            vPortYield();   // Give higher-priority tasks the opportunity to run between each item
+            drain_ringbuffer(true);
+        }
+#else
+        vTaskDelay(pdMS_TO_TICKS(next_check_delay_ms));
+#endif
+    }
+    __unreachable();
+}
+#endif
 
 int esp_log_router_flash_vprintf(const char *format, va_list args)
 {
     int ret = 0;
     if (g_esp_log_router_keep_console && g_esp_log_router_vprintf) {
         ret = g_esp_log_router_vprintf(format, args);
+    } else {
+        // We'll need to figure out how many bytes are needed ourselves
+        ret = vsnprintf(NULL, 0, format, args);
     }
 
+    if (ret < 0) {
+        log_router_debug_printf("console vprintf() returned %d: %s\n", ret, strerror(errno));
+    } else if (ret == 0) {
+        return ret; // No point saving completely blank messages
+    }
+
+    // Now we know how many bytes we need to fit the message.
+    size_t predicted_len = ret;
+
+    // Optimisation: don't bother with e.g. DEBUG messages if the highest level is INFO
+    // This means we don't have to (1) format the message (2) fill/empty the ringbuffer
+    // and (3) lock and iterate through the list.
     const char *p = strchr(format, '(');
     if (!p || p <= format || (p - format) < 2) {
-        return ESP_ERR_INVALID_ARG;
+        log_router_debug_printf("Parse failure in format string: '%s'", format);
+        return ret;
     }
-
     char level_char = *(p - 2);
-    esp_log_level_t msg_level;
-
-    switch (level_char) {
-    case 'E': msg_level = ESP_LOG_ERROR; break;
-    case 'W': msg_level = ESP_LOG_WARN; break;
-    case 'I': msg_level = ESP_LOG_INFO; break;
-    case 'D': msg_level = ESP_LOG_DEBUG; break;
-    case 'V': msg_level = ESP_LOG_VERBOSE; break;
-    default:  msg_level = ESP_LOG_NONE;
+    esp_log_level_t msg_level = char_to_level(level_char);
+    if (msg_level > g_level_max) {
+        return ret;
     }
 
-    // Lock mutex for thread safety
-    xSemaphoreTake(g_log_router_mutex, portMAX_DELAY);
-
-    // Write to all files that match the log level
-    esp_log_router_slist_t *item;
-    int len = vsnprintf(vprintf_buffer, sizeof(vprintf_buffer), format, args);
-    if (len > 0) {
-        int trunc_b = 0;
-        if (len > (sizeof(vprintf_buffer) - 1)) {
-            trunc_b = len - (sizeof(vprintf_buffer) - 1);
-            log_router_debug_printf("Buffer too small, lost %d bytes\n", trunc_b);
-            len = sizeof(vprintf_buffer) - 1;
-        }
-
-        vprintf_buffer[len] = '\0';
-        uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
-
-        // Extract tag from formatted buffer (find the colon ':')
-        const char *colon_pos = strchr(vprintf_buffer, ':');
-        const char *tag_start = NULL;
-        size_t tag_len = 0;
-
-        if (colon_pos) {
-            // Find the start of tag (after the closing parenthesis)
-            tag_start = strchr(vprintf_buffer, ')');
-            if (tag_start && tag_start < colon_pos) {
-                tag_start++; // Skip ')'
-                // Skip any spaces
-                while (tag_start < colon_pos && (*tag_start == ' ' || *tag_start == '\t')) {
-                    tag_start++;
-                }
-                // Calculate tag length
-                tag_len = colon_pos - tag_start;
-                if (tag_len > 0) {
-                    log_router_debug_printf("Extracted tag: '%.*s' (len=%zu)\n", (int)tag_len, tag_start, tag_len);
-                }
-            }
-        }
-
-        SLIST_FOREACH(item, &g_esp_log_router_slist_head, next) {
-            // Check level and tag match
-            bool level_match = (msg_level <= item->level);
-            bool tag_match = (item->tag == NULL) || (tag_len > 0 && strncmp(tag_start, item->tag, tag_len) == 0 && item->tag[tag_len] == '\0');
-
-            if (level_match && tag_match && item->log_fp) {
-                router_fwrite(vprintf_buffer, 1, len, item, now);
-
-#if (CONFIG_LOG_ROUTER_APPEND_STRING_ON_TRUNCATE)
-                if (trunc_b > 0) {
-                    router_fwrite(TRUNCATE_MESSAGE, 1, strlen(TRUNCATE_MESSAGE), item, now);
-                }
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+    vprintf_ringbuffer(format, args, predicted_len);
+#else
+    vprintf_no_ringbuffer(format, args, predicted_len);
 #endif
-            }
-        }
-    }
-
-    // Release mutex
-    xSemaphoreGive(g_log_router_mutex);
 
     return ret;
 }
 
+//! Find the log file in the list.
+//! @retval NULL    File is not currently a log target
+static esp_log_router_slist_t* lookup_item(const char* file_path)
+{
+    assert(MUTEX_LOCKED(g_slist_mutex));
+
+    esp_log_router_slist_t* found = NULL;
+
+    esp_log_router_slist_t *item;
+    SLIST_FOREACH(item, &g_esp_log_router_slist_head, next) {
+        if (strcmp(item->file_path, file_path) == 0) {
+            found = item;
+            break;
+        }
+    }
+
+    return found;
+}
+
+// Mark redundant free() calls; the esp32 will clear the heap when it restarts
+#define LOG_ROUTER_FREE_MEMORY_ON_SHUTDOWN false
+
+#if (CONFIG_LOG_ROUTER_FLUSH_BUFFERS_ON_RESTART)
+
+//! Callback executed by esp_restart() - i.e. a 'clean' restart (not a panic).
+//! Ensures that all messages are saved to disk before restarting.
 static void esp_log_router_shutdown(void)
 {
-    esp_log_router_slist_t *item, *temp;
+    log_router_debug_printf("Flush buffers and close files prior to restart\n");
 
-    // Just close all file handles directly
+    // Restore original vprintf function - prevents new messages from being added to the log_router
+    if (g_esp_log_router_vprintf) {
+        esp_log_set_vprintf(g_esp_log_router_vprintf);
+        g_esp_log_router_vprintf = NULL;
+    }
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+    // Process queued messages in the ringbuffer.
+
+    const size_t todo = rb_items_waiting(); // Only those messages currently in the ringbuffer
+
+    for (int i = 0; i < todo; i++) {
+        esp_err_t err = drain_one_from_ringbuffer(0, NULL);
+        if (err != ESP_OK) {
+            break;
+        }
+    }
+#endif
+
+    // Lock mutex while accessing the list.
+    BaseType_t ret = xSemaphoreTake(g_slist_mutex, pdMS_TO_TICKS(CONFIG_LOG_ROUTER_SHUTDOWN_HANDLER_TIMEOUT_MS));
+    if (ret != pdTRUE) {
+        // Another task either forgot to release the mutex, or got stuck while using it
+        ESP_ERROR_CHECK(ESP_ERR_TIMEOUT);   // Abort immediately, showing the stack trace.
+        __unreachable();
+    }
+
+    esp_log_router_slist_t *item, *temp;
     SLIST_FOREACH_SAFE(item, &g_esp_log_router_slist_head, next, temp) {
+
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE)
+        // Flush batch buffer to disk.
+        esp_log_router_flush_buffer(item);
+#endif
+
+        // make sure file data is on disk before closing it
         if (item->log_fp) {
+            fflush(item->log_fp);
+            fsync(fileno(item->log_fp));
             fclose(item->log_fp);
             item->log_fp = NULL;
         }
 
+#if (LOG_ROUTER_FREE_MEMORY_ON_SHUTDOWN)
         // Free allocated memory
         if (item->file_path) {
             free(item->file_path);
@@ -301,64 +711,120 @@ static void esp_log_router_shutdown(void)
         if (item->buffer) {
             free(item->buffer);
         }
-
         // Remove from list and free node
         SLIST_REMOVE(&g_esp_log_router_slist_head, item, _esp_log_router_slist_t, next);
         free(item);
+#endif
     }
 
-    // Restore original vprintf function
-    if (g_esp_log_router_vprintf) {
-        esp_log_set_vprintf(g_esp_log_router_vprintf);
-        g_esp_log_router_vprintf = NULL;
+    // We may as well keep the mutex locked for the rest of esp_restart().
+    assert(MUTEX_LOCKED(g_slist_mutex));
+
+    return;
+}
+
+#endif
+
+static esp_err_t init_globals_once()
+{
+    // Create mutex for thread safety, the first time this function is called.
+    g_slist_mutex = xSemaphoreCreateMutex();
+    ESP_RETURN_ON_FALSE(NULL != g_slist_mutex, ESP_ERR_NO_MEM, TAG, "Failed to create slist mutex!");
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+    // Initialise the ringbuffer
+    // Depending on KConfig options it may be statically allocated, or even allocated in PSRAM.
+#if (CONFIG_LOG_ROUTER_RINGBUFFER_STATIC)
+    g_ringbuf = xRingbufferCreateStatic(CONFIG_LOG_ROUTER_RINGBUFFER_SIZE, RINGBUF_TYPE_NOSPLIT, ringbufferStorage, &staticRingbuffer);
+#else
+#if (CONFIG_LOG_ROUTER_RINGBUFFER_IN_EXT)
+    UBaseType_t uxMemoryCaps = HEAP_CAP_DEFAULT_SPIRAM
+#else
+    UBaseType_t uxMemoryCaps = HEAP_CAP_DEFAULT_INTERNAL;
+#endif
+                               g_ringbuf = xRingbufferCreateWithCaps(CONFIG_LOG_ROUTER_RINGBUFFER_SIZE, RINGBUF_TYPE_NOSPLIT, uxMemoryCaps);
+#endif
+    ESP_RETURN_ON_FALSE(NULL != g_ringbuf, ESP_ERR_NO_MEM, TAG, "Failed to create ringbuffer!");
+
+    g_ringbuf_drain_mutex = xSemaphoreCreateMutex();
+    ESP_RETURN_ON_FALSE(NULL != g_ringbuf_drain_mutex, ESP_ERR_NO_MEM, TAG, "Failed to create ringbuffer mutex!");
+
+    if (g_ringbuf_drain_mutex == NULL) {
+        ESP_LOGE(TAG, "Failed to create ringbuffer mutex!");
+        return ESP_ERR_NO_MEM;
     }
 
-    // Reset global state
-    g_esp_log_router_keep_console = true;
+#endif
+
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE || CONFIG_LOG_ROUTER_RINGBUFFER)
+    // This task has two responsibilities:
+    // (1) Draining the ringbuffer in the background
+    // (2) Flushing the batch buffers after a defined timeout period
+    ESP_RETURN_ON_FALSE(NULL == g_log_router_drain_task, ESP_ERR_INVALID_STATE, TAG, "");
+    BaseType_t ret = xTaskCreatePinnedToCore(
+                         &log_router_drain_task,
+                         CONFIG_LOG_ROUTER_TASK_NAME,
+                         CONFIG_LOG_ROUTER_TASK_STACK_DEPTH,
+                         NULL,
+                         CONFIG_LOG_ROUTER_TASK_PRIORITY,
+                         &g_log_router_drain_task,
+                         CONFIG_LOG_ROUTER_TASK_CORE_AFFINITY
+                     );
+    if (ret != pdPASS) {
+        return ESP_FAIL;    // errno NOT set
+    }
+#endif
+
+#if (CONFIG_LOG_ROUTER_FLUSH_BUFFERS_ON_RESTART)
+    // Shutdown handler ensures buffers are flushed, and files are closed and sync'd
+    ESP_RETURN_ON_ERROR(esp_register_shutdown_handler(esp_log_router_shutdown), TAG, "");
+#endif
+
+    return ESP_OK;
 }
 
 esp_err_t esp_log_router_to_file(const char* file_path, const char* tag, esp_log_level_t level)
 {
-    // Create mutex for thread safety, the first time this function is called.
-    if (g_log_router_mutex == NULL) {
-        g_log_router_mutex = xSemaphoreCreateMutex();
-        if (g_log_router_mutex == NULL) {
-            ESP_LOGE(TAG, "Failed to create mutex for log router");
-            return ESP_ERR_NO_MEM;
-        }
+    static bool once = false;
+    if (!once) {
+        ESP_ERROR_CHECK(init_globals_once());
+        once = true;
     }
 
     if (!file_path) {
         return ESP_ERR_INVALID_ARG;
     }
 
+    // Lock mutex while accessing the list
+    xSemaphoreTake(g_slist_mutex, portMAX_DELAY);
+
     // Check if file path already exists
-    esp_log_router_slist_t *item;
-    SLIST_FOREACH(item, &g_esp_log_router_slist_head, next) {
-        if (strcmp(item->file_path, file_path) == 0) {
-            // File path already exists, update configuration
-            item->level = level;
+    esp_log_router_slist_t *item = lookup_item(file_path);
+    if (item) {
+        // File path already exists, update configuration
+        item->level = level;
+        g_level_max = MAX(g_level_max, item->level);
 
-            // Update tag
-            if (item->tag) {
-                free(item->tag);
-            }
-            if (tag) {
-                item->tag = strdup(tag);
-                if (!item->tag) {
-                    return ESP_ERR_NO_MEM;
-                }
-            } else {
-                item->tag = NULL;
-            }
-
-            return ESP_OK;
+        // Update tag
+        if (item->tag) {
+            free(item->tag);
+            item->tag = NULL;
         }
+        if (tag) {
+            item->tag = strdup(tag);
+            if (!item->tag) {
+                xSemaphoreGive(g_slist_mutex);
+                return ESP_ERR_NO_MEM;
+            }
+        }
+        xSemaphoreGive(g_slist_mutex);
+        return ESP_OK;
     }
 
     // Create new node
     esp_log_router_slist_t *new_log_router = calloc(1, sizeof(esp_log_router_slist_t));
     if (!new_log_router) {
+        xSemaphoreGive(g_slist_mutex);
         return ESP_ERR_NO_MEM;
     }
 
@@ -366,6 +832,7 @@ esp_err_t esp_log_router_to_file(const char* file_path, const char* tag, esp_log
     new_log_router->file_path = strdup(file_path);
     if (!new_log_router->file_path) {
         free(new_log_router);
+        xSemaphoreGive(g_slist_mutex);
         return ESP_ERR_NO_MEM;
     }
 
@@ -375,6 +842,7 @@ esp_err_t esp_log_router_to_file(const char* file_path, const char* tag, esp_log
         if (!new_log_router->tag) {
             free(new_log_router->file_path);
             free(new_log_router);
+            xSemaphoreGive(g_slist_mutex);
             return ESP_ERR_NO_MEM;
         }
     } else {
@@ -386,34 +854,44 @@ esp_err_t esp_log_router_to_file(const char* file_path, const char* tag, esp_log
     if (!new_log_router->log_fp) {
         free(new_log_router->file_path);
         free(new_log_router);
+        xSemaphoreGive(g_slist_mutex);
         return ESP_FAIL;
     }
 
     // Set log level
     new_log_router->level = level;
+    g_level_max = MAX(g_level_max, new_log_router->level);
 
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE)
     // Initialize buffer and flush settings
     new_log_router->buffer_size = CONFIG_LOG_ROUTER_BUFFER_SIZE;
-    new_log_router->buffer = calloc(1, new_log_router->buffer_size);
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE_BUFFER_PREFER_EXT_RAM)
+    new_log_router->buffer = CALLOC_PREFER_EXTERNAL(1, new_log_router->buffer_size);
+#else
+    new_log_router->buffer = CALLOC_PREFER_PERFORMANCE(1, new_log_router->buffer_size);
+#endif
+    new_log_router->flush_timeout_ms = CONFIG_LOG_ROUTER_FLUSH_TIMEOUT_MS;
     if (!new_log_router->buffer) {
         fclose(new_log_router->log_fp);
         free(new_log_router->file_path);
         free(new_log_router);
+        xSemaphoreGive(g_slist_mutex);
         return ESP_ERR_NO_MEM;
     }
 
-    // Calculate flush threshold based on percentage
-    new_log_router->flush_threshold = (new_log_router->buffer_size * CONFIG_LOG_ROUTER_FLUSH_THRESHOLD_PERCENT) / 100;
     new_log_router->flush_timeout_ms = CONFIG_LOG_ROUTER_FLUSH_TIMEOUT_MS;
     new_log_router->buffer_pos = 0;
-    new_log_router->last_flush_time = (uint32_t)(esp_timer_get_time() / 1000);
+//    new_log_router->last_flush_time = (uint32_t)(esp_timer_get_time() / 1000);    // ignored when buffer_pos = 0
+#endif
+
+    // The list should still be under lock
+    assert(MUTEX_LOCKED(g_slist_mutex));
 
     // Insert after the first node (if exists) or as first node
     if (SLIST_EMPTY(&g_esp_log_router_slist_head)) {
         // If list is empty, insert as first node and set vprintf redirect
         SLIST_INSERT_HEAD(&g_esp_log_router_slist_head, new_log_router, next);
         g_esp_log_router_vprintf = esp_log_set_vprintf(esp_log_router_flash_vprintf);
-        esp_register_shutdown_handler(esp_log_router_shutdown);
     } else {
         // Find the last node and insert after it
         esp_log_router_slist_t *last = SLIST_FIRST(&g_esp_log_router_slist_head);
@@ -423,6 +901,9 @@ esp_err_t esp_log_router_to_file(const char* file_path, const char* tag, esp_log
         SLIST_INSERT_AFTER(last, new_log_router, next);
     }
 
+    // Release mutex
+    xSemaphoreGive(g_slist_mutex);
+
     return ESP_OK;
 }
 
@@ -431,11 +912,72 @@ void esp_log_router_to_console(bool output_console)
     g_esp_log_router_keep_console = output_console;
 }
 
-esp_err_t esp_log_delete_router(const char* file_path)
+esp_err_t esp_log_router_sync_file(const char* file_path, struct stat *sbuf)
 {
     if (!file_path) {
         return ESP_ERR_INVALID_ARG;
     }
+
+    ESP_LOGI(TAG, "Sync logs to file: %s", file_path);
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+    // There may be messages in the ringbuffer!
+    drain_ringbuffer(true);
+#endif
+
+#if (!CONFIG_LOG_ROUTER_BATCH_WRITE)
+    return ESP_OK;
+#else
+    // A per-file buffer needs to be flushed as well
+
+    // Lock mutex while accessing the list
+    xSemaphoreTake(g_slist_mutex, portMAX_DELAY);
+
+    esp_log_router_slist_t *item = lookup_item(file_path);
+    if (!item) {
+        xSemaphoreGive(g_slist_mutex);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // Flush buffer. Also calls fsync.
+    esp_err_t err = esp_log_router_flush_buffer(item);
+    if (err != ESP_OK) {
+        xSemaphoreGive(g_slist_mutex);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    if (sbuf != NULL) {
+        // While we have the mutex locked, check how large the file is
+        int ret = fstat(fileno(item->log_fp), sbuf);
+
+        if (ret != 0) {
+            log_router_debug_printf("fstat failed: %s", strerror(errno));
+            xSemaphoreGive(g_slist_mutex);
+            return ESP_FAIL;
+        }
+    }
+
+    // Release mutex
+    xSemaphoreGive(g_slist_mutex);
+    return ESP_OK;
+#endif
+}
+
+esp_err_t esp_log_router_stop_file(const char* file_path)
+{
+    if (!file_path) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+#if (CONFIG_LOG_ROUTER_RINGBUFFER)
+    // There may be messages in the ringbuffer!
+    drain_ringbuffer(true);
+#endif
+
+    // Lock mutex while accessing the list
+    xSemaphoreTake(g_slist_mutex, portMAX_DELAY);
+
+    esp_err_t found = ESP_ERR_NOT_FOUND;
 
     esp_log_router_slist_t *item, *prev = NULL;
     SLIST_FOREACH(item, &g_esp_log_router_slist_head, next) {
@@ -446,15 +988,22 @@ esp_err_t esp_log_delete_router(const char* file_path)
                 SLIST_REMOVE_HEAD(&g_esp_log_router_slist_head, next);
             }
 
+#if (CONFIG_LOG_ROUTER_BATCH_WRITE)
             // Flush buffer before closing
             esp_log_router_flush_buffer(item);
-
+            free(item->buffer);
+#endif
+            // make sure file data is on disk before closing it
+            fflush(item->log_fp);
+            fsync(fileno(item->log_fp));
             fclose(item->log_fp);
+            item->log_fp = NULL;
+
             free(item->file_path);
             if (item->tag) {
                 free(item->tag);
             }
-            free(item->buffer);
+
             free(item);
 
             // If this was the last item, restore original vprintf
@@ -464,11 +1013,25 @@ esp_err_t esp_log_delete_router(const char* file_path)
             }
 
             ESP_LOGI(TAG, "Log router deleted: %s", file_path);
-            return ESP_OK;
+
+            found = ESP_OK;
+            break;
         }
         prev = item;
     }
-    return ESP_ERR_NOT_FOUND;
+
+    // The maximum level may have reduced
+    esp_log_level_t new_max = 0;    // a.k.a. ESP_LOG_NONE
+//    esp_log_router_slist_t *item;
+    SLIST_FOREACH(item, &g_esp_log_router_slist_head, next) {
+        new_max = MAX(new_max, item->level);
+    }
+    g_level_max = new_max;  // Atomic write
+
+    // Release mutex
+    xSemaphoreGive(g_slist_mutex);
+
+    return found;
 }
 
 esp_err_t esp_log_router_dump_file_messages(const char* file_path)
@@ -476,6 +1039,32 @@ esp_err_t esp_log_router_dump_file_messages(const char* file_path)
     if (!file_path) {
         return ESP_ERR_INVALID_ARG;
     }
+
+    // Sync all pending messages, and record the file size (while the mutex is locked).
+    struct stat st;
+    esp_err_t err = esp_log_router_sync_file(file_path, &st);
+    if (err != ESP_OK) {
+        if (ESP_ERR_NOT_FOUND == err) {
+            // The file is not being logged to at the moment, but that's fine.
+            printf("Note: file '%s' is not currently a log target", file_path);
+
+            int ret = stat(file_path, &st);
+            if (ret != 0) {
+                // No file at all?
+                log_router_debug_printf("unable to stat '%s': %s", file_path, strerror(errno));
+                return ESP_FAIL;
+            }
+        } else {
+            return err;
+        }
+    }
+
+    // Only print what's been sync'd - otherwise, there's a risk of printing message fragments.
+    off_t todo = st.st_size;
+
+    log_router_debug_printf("dumping %ld bytes from '%s'", todo, file_path);
+
+    char dump_log_buffer[256];
 
     FILE *fp = fopen(file_path, "r");
     if (!fp) {
@@ -486,13 +1075,33 @@ esp_err_t esp_log_router_dump_file_messages(const char* file_path)
     printf("File content: %s\n", file_path);
     int line_count = 0;
 
-    while (fgets(dump_log_buffer, sizeof(dump_log_buffer), fp) != NULL) {
+    bool eof_or_error = false;
+    while (todo > 0 && !eof_or_error) {
+        size_t bytes_read = fread(dump_log_buffer, 1, sizeof(dump_log_buffer), fp);
+        eof_or_error = bytes_read < sizeof(dump_log_buffer);
+
         printf("%s", dump_log_buffer);
+
+        // Count number of lines
+        for (int i = 0; i < bytes_read; i++) {
+            if (dump_log_buffer[i] == '\n') {
+                line_count++;
+            }
+        }
+
+        todo -= bytes_read;
+
         vTaskDelay(pdMS_TO_TICKS(10)); /*!< Avoid triggering watchdog */
-        line_count++;
+    }
+
+    if (ferror(fp)) {
+        printf("Read error on line %d\n", line_count + 1);
+        return ESP_FAIL;
     }
 
     printf("End of file (total %d lines)\n", line_count);
     fclose(fp);
-    return ESP_OK;
+
+    assert(err == ESP_OK || err == ESP_ERR_NOT_FOUND);
+    return err;
 }

--- a/components/utilities/log_router/priv_include/log_router_macros.h
+++ b/components/utilities/log_router/priv_include/log_router_macros.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ *
+ */
+
+#pragma once
+
+#include <stdio.h>
+#include "esp_heap_caps.h"
+
+// ---- Logging macros ---- //
+
+// ---- Performance logging macros ---- //
+
+// Begin timing. _name must be unique for each measurement within a function
+#define LOG_ROUTER_DEBUG_TIMING_BEGIN(_name) \
+    int64_t __timing_start_##_name = esp_timer_get_time();
+
+// Finish timing
+#define LOG_ROUTER_DEBUG_TIMING_END(_name) \
+    uint32_t __timing_duration_us##_name = esp_timer_get_time() - __timing_start_##_name; \
+
+// Finish timing, print function/lineno/result and a user-defined message
+#define LOG_ROUTER_DEBUG_TIMING_END_MSG(_name, format, ...) \
+    uint32_t __timing_duration_us##_name = esp_timer_get_time() - __timing_start_##_name; \
+    log_router_debug_printf("%s(%d): %ums: "format, __FUNCTION__, __LINE__, __timing_duration_us##_name / 1000, ##__VA_ARGS__);
+
+// Resolves to the measurement with the corresponding _name
+#define LOG_ROUTER_DEBUG_TIMING_RESULT(_name) __timing_duration_us##_name
+
+// ---- Heap allocation macros ---- //
+
+// capability flag combinations
+#define HEAP_CAP_DEFAULT_ANY          (MALLOC_CAP_DEFAULT)
+#define HEAP_CAP_DEFAULT_SPIRAM       (MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM)
+#define HEAP_CAP_DEFAULT_INTERNAL     (MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
+
+// Prefer external PSRAM, to reduce fragmentation of precious SRAM
+#define MALLOC_PREFER_EXTERNAL(size) heap_caps_malloc_prefer((size), 2,( HEAP_CAP_DEFAULT_SPIRAM), HEAP_CAP_DEFAULT_ANY)
+#define CALLOC_PREFER_EXTERNAL(n, size) heap_caps_calloc_prefer((n), (size), 2,( HEAP_CAP_DEFAULT_SPIRAM), HEAP_CAP_DEFAULT_ANY)
+#define REALLOC_PREFER_EXTERNAL(ptr, size) heap_caps_realloc_prefer((ptr), (size), 2, HEAP_CAP_DEFAULT_SPIRAM, HEAP_CAP_DEFAULT_ANY)
+
+// Use internal memory when performance is desirable and fragmentation can be minimised
+#define MALLOC_PREFER_PERFORMANCE(size) heap_caps_malloc_prefer((size), 2, HEAP_CAP_DEFAULT_INTERNAL, HEAP_CAP_DEFAULT_ANY)
+#define CALLOC_PREFER_PERFORMANCE(n, size) heap_caps_calloc_prefer((n), (size), 2, HEAP_CAP_DEFAULT_INTERNAL, HEAP_CAP_DEFAULT_ANY)
+#define REALLOC_PREFER_PERFORMANCE(ptr, size) heap_caps_realloc_prefer((ptr), (size), 2, HEAP_CAP_DEFAULT_INTERNAL, HEAP_CAP_DEFAULT_ANY)
+
+// Fails when internal memory not available, allowing the caller to try again with a smaller buffer
+#define MALLOC_PERFORMANCE(size) heap_caps_malloc((size), HEAP_CAP_DEFAULT_INTERNAL)
+#define CALLOC_PERFORMANCE(n, size) heap_caps_calloc((n), (size), HEAP_CAP_DEFAULT_INTERNAL)
+#define REALLOC_PERFORMANCE(ptr, size) heap_caps_realloc((ptr), (size), 2, HEAP_CAP_DEFAULT_INTERNAL)


### PR DESCRIPTION
Upstreaming improvements to the log_router component, made while using it in production.

Squashed together, all the changes amount to a rewrite; only the ``esp_log_router_slist_t`` is (mostly) untouched. I neither expect, nor require, this to be merged quickly : ) .

## Description

There were 4 problems I encountered while using the log_router in production
1. The 'timeout flush' didn't. No timer or task would wake up to perform the flush; instead, it happened the next time that ``esp_log_router_flash_vprintf()`` was called. This meant that the log file consistently lacked the most recent message(s) that should have been written to it.
2. Calls to the ESP_LOG*() functions took a long time, because ``esp_log_router_flash_vprintf()`` would have to perform file IO.
3. The shutdown handler was not flushing the buffers, meaning messages were missing after a call to esp_restart().
4. There was no indicator for when a string had been truncated.

This patch addresses these issues:

1. The log_router now starts a low-priority task ``log_router_drain_task``. It will keep track of the buffer timeout, and flush them to disk when necessary.
2. ``esp_log_router_flash_vprintf()`` no longer performs file I/O*. Instead, it prints each message into a zero-copy, thread-safe ringbuffer. The ``log_router_drain_task`` runs in the background; it determines the level and tag, and writes to the appropriate buffers and files.
3. The shutdown handler will now ensure that the ringbuffer is empty, all buffers are flushed, and the files sync'd and closed.
4. Truncation is much less likely, because up to half of the ringbuffer can be used for formatting a message. The ringbuffer is intended to be large, to improve performance. There is also the same check as in: https://github.com/espressif/esp-iot-solution/pull/7181

_*If the ringbuffer is full, ``esp_log_router_flash_vprintf()`` will help drain messages until the buffer has enough space for the new message_

There are KConfig options to control the buffering behaviour:
- The ringbuffer is optional.
- The per-file buffer is also optional.
  - Yes, this means it can operate with no buffering at all. Slow, but simple.
- Size of the ringbuffer.
- Size of each per-file buffer.
- Allocate ringbuffer in PSRAM (not recommended - it slows down log calls).
- Allocate per-file buffer in PSRAM (recommended; it only slows down the background task).
- Static allocate the ringbuffer's memory.

Some other changes/features worth mentioning:
- ``esp_log_router_status_file()`` Test if a file is currently a log target.
- ``esp_log_router_sync_file()`` Guarantees that any log messages (prior to calling this function) intended for this file have been written to it. Also returns the number of bytes that are in the file, which is useful for preventing race-conditions (see ``esp_log_router_dump_file_messages() for an example``).
- ``esp_log_router_dump_file_messages()`` now uses ``esp_log_router_sync_file()`` to make sure any buffered messages are included in the output.

## Related

Includes the fixes in: https://github.com/espressif/esp-iot-solution/pull/718

## Testing

Existing tests in `test_app/` were run, in all four 'modes', on an ESP32-S3.
- Ringbuffer & batch-buffers.
- Batch-buffers only.
- Ringbuffer only.
- No buffers.
All 3 tests pass in each mode.

It is also being used in production code as part of a large ADF project with many concurrent tasks. Settings used are the current defaults in KConfig. In particular:
- File system is fatfs, on eMMC.
- Both the ringbuffer and batch-buffers are enabled.
- Batch-buffers are allocated in PSRAM
- ringbuffer is dynamically allocated (not static).





---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
