### PR TITLE
feat(lcd): add ST7701 MIPI init control flags

### DIFF
--- a/components/display/lcd/esp_lcd_st7701/CHANGELOG.md
+++ b/components/display/lcd/esp_lcd_st7701/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Enhancements:
+
+* Add MIPI vendor flags to skip automatic software reset and MADCTL/COLMOD commands
+
 ## v2.0.2~2 - 2026-05-28
 
 ### Changes:

--- a/components/display/lcd/esp_lcd_st7701/esp_lcd_st7701_mipi.c
+++ b/components/display/lcd/esp_lcd_st7701/esp_lcd_st7701_mipi.c
@@ -40,6 +40,8 @@ typedef struct {
     uint16_t init_cmds_size;
     struct {
         unsigned int reset_level: 1;
+        unsigned int skip_sw_reset: 1;
+        unsigned int skip_auto_cmds: 1;
     } flags;
     // To save the original functions of MIPI DPI panel
     esp_err_t (*del)(esp_lcd_panel_t *panel);
@@ -97,6 +99,8 @@ esp_err_t esp_lcd_new_panel_st7701_mipi(const esp_lcd_panel_io_handle_t io, cons
     st7701->init_cmds_size = vendor_config->init_cmds_size;
     st7701->reset_gpio_num = panel_dev_config->reset_gpio_num;
     st7701->flags.reset_level = panel_dev_config->flags.reset_active_high;
+    st7701->flags.skip_sw_reset = vendor_config->flags.skip_mipi_sw_reset;
+    st7701->flags.skip_auto_cmds = vendor_config->flags.skip_mipi_auto_cmds;
 
     // Create MIPI DPI panel
     esp_lcd_panel_handle_t panel_handle = NULL;
@@ -155,7 +159,7 @@ static esp_err_t panel_st7701_reset(esp_lcd_panel_t *panel)
         vTaskDelay(pdMS_TO_TICKS(10));
         gpio_set_level(st7701->reset_gpio_num, !st7701->flags.reset_level);
         vTaskDelay(pdMS_TO_TICKS(10));
-    } else if (io) { // perform software reset
+    } else if (io && !st7701->flags.skip_sw_reset) { // perform software reset
         ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_CMD_SWRESET, NULL, 0), TAG, "send command failed");
         vTaskDelay(pdMS_TO_TICKS(20)); // spec, wait at least 5ms before sending new command
     }
@@ -223,17 +227,21 @@ static esp_err_t panel_st7701_init(esp_lcd_panel_t *panel)
     ESP_RETURN_ON_ERROR(esp_lcd_panel_io_rx_param(io, 0x04, ID, 3), TAG, "read ID failed");
     ESP_LOGI(TAG, "LCD ID: %02X %02X %02X", ID[0], ID[1], ID[2]);
 
-    // back to CMD_Page 0
-    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, ST7701_CMD_CND2BKxSEL, (uint8_t []) {
-        ST7701_CMD_BKxSEL_BYTE0, ST7701_CMD_BKxSEL_BYTE1, ST7701_CMD_BKxSEL_BYTE2, ST7701_CMD_BKxSEL_BYTE3, 0x00
-    }, 5), TAG, "Write cmd failed");
-    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
-        st7701->madctl_val,
-    }, 1), TAG, "send command failed");
-    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_CMD_COLMOD, (uint8_t[]) {
-        st7701->colmod_val,
-    }, 1), TAG, "send command failed");
-    ESP_LOGI(TAG, " st7701->madctl_val: 0x%x, st7701->colmod_val: 0x%x",  st7701->madctl_val, st7701->colmod_val);
+    if (!st7701->flags.skip_auto_cmds) {
+        // back to CMD_Page 0
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, ST7701_CMD_CND2BKxSEL, (uint8_t []) {
+            ST7701_CMD_BKxSEL_BYTE0, ST7701_CMD_BKxSEL_BYTE1, ST7701_CMD_BKxSEL_BYTE2, ST7701_CMD_BKxSEL_BYTE3, 0x00
+        }, 5), TAG, "Write cmd failed");
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
+            st7701->madctl_val,
+        }, 1), TAG, "send command failed");
+        ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, LCD_CMD_COLMOD, (uint8_t[]) {
+            st7701->colmod_val,
+        }, 1), TAG, "send command failed");
+        ESP_LOGI(TAG, " st7701->madctl_val: 0x%x, st7701->colmod_val: 0x%x",  st7701->madctl_val, st7701->colmod_val);
+    } else {
+        ESP_LOGI(TAG, "skip automatic MADCTL/COLMOD before vendor init");
+    }
 
     // vendor specific initialization, it can be different between manufacturers
     // should consult the LCD supplier for initialization sequence code

--- a/components/display/lcd/esp_lcd_st7701/include/esp_lcd_st7701.h
+++ b/components/display/lcd/esp_lcd_st7701/include/esp_lcd_st7701.h
@@ -73,6 +73,8 @@ typedef struct {
              *   Please set it to 1 to release the panel IO and its pins (except CS signal).
              *   This flag is only valid for the RGB interface.
              */
+        unsigned int skip_mipi_sw_reset: 1;        /*!< Skip automatic software reset command for MIPI panels */
+        unsigned int skip_mipi_auto_cmds: 1;       /*!< Skip automatic MADCTL/COLMOD writes before custom MIPI init */
     } flags;
 } st7701_vendor_config_t;
 


### PR DESCRIPTION
### Description

Add two opt-in MIPI vendor flags to the ST7701 LCD component:

- `skip_mipi_sw_reset`: skip the automatic software reset command in the MIPI reset path.
- `skip_mipi_auto_cmds`: skip the automatic MADCTL/COLMOD writes before vendor initialization commands.

Some MIPI ST7701 panels require the panel-specific initialization table to control reset timing or to send page/color-format commands in a strict order. These flags allow that without changing the default driver behavior.

The default behavior remains unchanged when both flags are left unset.

### Testing

- `git diff --check`
- `uvx pre-commit run --files components/display/lcd/esp_lcd_st7701/CHANGELOG.md components/display/lcd/esp_lcd_st7701/esp_lcd_st7701_mipi.c components/display/lcd/esp_lcd_st7701/include/esp_lcd_st7701.h`

Most pre-commit hooks passed, including copyright, whitespace, mixed line endings, astyle, executable checks, and codespell.

The `release_versions` hook failed while scanning existing test app manifests that do not contain a `version` key, for example `components/display/lcd/esp_lcd_st7701/test_apps/main/idf_component.yml`. This does not appear to be introduced by this change.

I did not run an IDF build locally because `idf.py` is not available in my current Windows shell.
