### PR TITLE
Fix for AXS15231B on_off reverse implementation

### DIFF
--- a/components/display/lcd/esp_lcd_axs15231b/CHANGELOG.md
+++ b/components/display/lcd/esp_lcd_axs15231b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v3.0.0 - 2026-07-18
+
+* `panel_axs15231b_disp_off` behaviour was inverted and is now fixed. Update your `esp_lcd_panel_disp_on_off()` usages.
+
 ## v2.1.0 - 2026-01-21
 
 ### Enhancements:

--- a/components/display/lcd/esp_lcd_axs15231b/esp_lcd_axs15231b.c
+++ b/components/display/lcd/esp_lcd_axs15231b/esp_lcd_axs15231b.c
@@ -39,7 +39,7 @@ static esp_err_t panel_axs15231b_invert_color(esp_lcd_panel_t *panel, bool inver
 static esp_err_t panel_axs15231b_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y);
 static esp_err_t panel_axs15231b_swap_xy(esp_lcd_panel_t *panel, bool swap_axes);
 static esp_err_t panel_axs15231b_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap);
-static esp_err_t panel_axs15231b_disp_off(esp_lcd_panel_t *panel, bool off);
+static esp_err_t panel_axs15231b_disp_on_off(esp_lcd_panel_t *panel, bool on);
 
 static esp_err_t touch_axs15231b_read_data(esp_lcd_touch_handle_t tp);
 static bool touch_axs15231b_get_xy(esp_lcd_touch_handle_t tp, uint16_t *x, uint16_t *y, uint16_t *strength, uint8_t *point_num, uint8_t max_point_num);
@@ -147,7 +147,7 @@ esp_err_t esp_lcd_new_panel_axs15231b(const esp_lcd_panel_io_handle_t io, const 
     axs15231b->base.set_gap = panel_axs15231b_set_gap;
     axs15231b->base.mirror = panel_axs15231b_mirror;
     axs15231b->base.swap_xy = panel_axs15231b_swap_xy;
-    axs15231b->base.disp_on_off  = panel_axs15231b_disp_off;
+    axs15231b->base.disp_on_off  = panel_axs15231b_disp_on_off;
     *ret_panel = &(axs15231b->base);
     ESP_LOGD(TAG, "new axs15231b panel @%p", axs15231b);
     ESP_LOGI(TAG, "LCD panel create success, version: %d.%d.%d", ESP_LCD_AXS15231B_VER_MAJOR, ESP_LCD_AXS15231B_VER_MINOR,
@@ -402,15 +402,15 @@ static esp_err_t panel_axs15231b_set_gap(esp_lcd_panel_t *panel, int x_gap, int 
     return ESP_OK;
 }
 
-static esp_err_t panel_axs15231b_disp_off(esp_lcd_panel_t *panel, bool off)
+static esp_err_t panel_axs15231b_disp_on_off(esp_lcd_panel_t *panel, bool on)
 {
     axs15231b_panel_t *axs15231b = __containerof(panel, axs15231b_panel_t, base);
     esp_lcd_panel_io_handle_t io = axs15231b->io;
     int command = 0;
-    if (off) {
-        command = LCD_CMD_DISPOFF;
-    } else {
+    if (on) {
         command = LCD_CMD_DISPON;
+    } else {
+        command = LCD_CMD_DISPOFF;
     }
     tx_param(axs15231b, io, command, NULL, 0);
     return ESP_OK;

--- a/components/display/lcd/esp_lcd_axs15231b/idf_component.yml
+++ b/components/display/lcd/esp_lcd_axs15231b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.0"
+version: "3.0.0"
 description: ESP LCD & Touch AXS15231B
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/display/lcd/esp_lcd_axs15231b
 issues: https://github.com/espressif/esp-iot-solution/issues


### PR DESCRIPTION
## Description

esp_lcd has an API where  `on_off` should turn the display **on** when `true` is passed:

```c
/**
 * @brief Turn on or off the display
 *
 * ...
 * @param[in] on_off True to turns on display, False to turns off display
 * ...
esp_err_t esp_lcd_panel_disp_on_off(esp_lcd_panel_handle_t panel, bool on_off);
```

However, the AXS15231B implementation is in reverse (note the `bool off` parameter):

```c
static esp_err_t panel_axs15231b_disp_off(esp_lcd_panel_t *panel, bool off)
{
    // ...
    if (off) {
        command = LCD_CMD_DISPOFF;
    } else {
        command = LCD_CMD_DISPON;
    }
    // ...
}
```

And it is used like this:

```c
axs15231b->base.disp_on_off  = panel_axs15231b_disp_off;
```

Which is then proxied to `esp_lcd_panel_disp_on_off()`.

My change fixes this and implements the correct behaviour so that `esp_lcd_panel_disp_on_off()` works as expected with this panel.

## Testing

My test device is a Guition JC3248W535C.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
**IMPORTANT** This PR does not create a breaking change for the API, but the behaviour change can be considered a breaking change! I updated the version from 2.x to 3.x and documented the migration path.
- [x] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary. (note: please squash when merging!)