### PR TITLE
fix(i2c_bus): repeated i2c_bus_create() on the same port resets ref_counter and leaks the mutex

### DIFF
--- a/components/i2c_bus/i2c_bus_v2.c
+++ b/components/i2c_bus/i2c_bus_v2.c
@@ -101,7 +101,8 @@ i2c_bus_handle_t i2c_bus_create(i2c_port_t port, const i2c_config_t *conf)
     I2C_BUS_CHECK(conf != NULL, "pointer = NULL error", NULL);
     I2C_BUS_CHECK(conf->mode == I2C_MODE_MASTER, "i2c_bus only supports master mode", NULL);
 
-    if (i2c_master_get_bus_handle(port, &s_i2c_bus[port].bus_handle) == ESP_OK) {
+    if (!s_i2c_bus[port].is_init &&
+            i2c_master_get_bus_handle(port, &s_i2c_bus[port].bus_handle) == ESP_OK) {
         s_i2c_bus[port].is_init = true;
         s_i2c_bus[port].conf_activate = *conf;
         s_i2c_bus[port].bus_config.i2c_port = port;


### PR DESCRIPTION
i2c_bus_v2.c's own header comment describes i2c_bus_create() as working in a singleton mode per port: call it again for a port that's already set up and it should just reuse the existing bus rather than reinitializing it. That's exactly the behavior independent components rely on when they each grab the same physical I2C bus.

The check order at the top of i2c_bus_create() breaks this. It first calls i2c_master_get_bus_handle() to see whether this port already has a bus handle that was set up by something other than i2c_bus itself (this exists so i2c_bus can adopt a bus created directly through esp_driver_i2c). The trouble is that esp_driver_i2c's i2c_master_get_bus_handle() only checks whether the port is occupied, not who occupied it -- so once i2c_bus itself has successfully called i2c_new_master_bus() for a port (which happens on the very first i2c_bus_create() call), every later i2c_bus_create() call on that same port takes this same branch. That branch unconditionally does `mutex = xSemaphoreCreateMutex()` (dropping the previous mutex handle without ever calling vSemaphoreDelete() on it) and `ref_counter = 0` (throwing away the device count from any i2c_bus_device_create() calls already made on that bus). The is_init + i2c_config_compare() reuse logic sitting right below it, which is supposed to handle exactly this case, ends up unreachable for any port i2c_bus itself owns.

I confirmed this by compiling the actual i2c_bus_v2.c against a small mock of the esp_driver_i2c calls it uses, modeled on how esp-idf's i2c_common.c/i2c_master.c really track port occupancy (a bus stays "occupied" once created, independent of caller). Sequence: create the bus, attach one device so ref_counter becomes 1, then call i2c_bus_create() again on the same port -- ref_counter comes back as 0 and a second mutex gets allocated while the first one is left referenced nowhere and never freed.

The fix just adds a guard so the "externally initialized" branch is only taken when i2c_bus hasn't already initialized this port itself (`!s_i2c_bus[port].is_init`). That keeps the adoption behavior working the first time there's a genuinely external bus handle, but once i2c_bus owns the port, later calls fall through to the existing dedup logic like the header doc says they should. Re-ran the same reproduction after the change and ref_counter stays at 1 with the mutex pointer reused instead of leaked.

I didn't have real hardware for this one, so this is verified by compiling the unmodified component logic against a behavior-accurate mock of the IDF calls it depends on, not an on-device test.
