### PR TITLE
fix(ble_conn_mgr): post ESP_BLE_CONN_EVENT_STARTED on host sync

### DIFF
--- a/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
+++ b/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
@@ -2840,6 +2840,11 @@ static void esp_ble_conn_on_sync(void)
     /* Begin scanning for a peripheral to connect to. */
     esp_ble_conn_scan(s_conn_session);
 #endif
+
+    /* Notify the application that the NimBLE host is synced and the stack is
+       ready (advertising/scanning have begun). */
+    esp_event_post(BLE_CONN_MGR_EVENTS, ESP_BLE_CONN_EVENT_STARTED,
+                   NULL, 0, portMAX_DELAY);
 }
 
 static void esp_ble_conn_on_gatts_register(struct ble_gatt_register_ctxt *ctxt, void *arg)

--- a/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
+++ b/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
@@ -2840,6 +2840,11 @@ static void esp_ble_conn_on_sync(void)
     /* Begin scanning for a peripheral to connect to. */
     esp_ble_conn_scan(s_conn_session);
 #endif
+
+    /* Notify the application that the NimBLE host is synced and the stack is
+       ready. */
+    esp_event_post(BLE_CONN_MGR_EVENTS, ESP_BLE_CONN_EVENT_STARTED,
+                   NULL, 0, portMAX_DELAY);
 }
 
 static void esp_ble_conn_on_gatts_register(struct ble_gatt_register_ctxt *ctxt, void *arg)


### PR DESCRIPTION
## Problem

`ESP_BLE_CONN_EVENT_STARTED` is declared in the public event enum:

```c
ESP_BLE_CONN_EVENT_STARTED = 1,  /*!< When BLE connection management start, the event comes */
```

…but it is **never posted** — grepping the sources shows it only appears in the
enum definition, never in an `esp_event_post(...)`. `STOPPED` and the other
events are posted normally.

## Impact

`ble_conn_mgr` owns `ble_hs_cfg.sync_cb` (`esp_ble_conn_on_sync`), so an
application cannot install its own NimBLE sync callback. With no `STARTED`
event, the only way to know the host has synced — e.g. to set a bonded-peer
whitelist, adjust advertising params, or open a pairing window **after** sync —
is to busy-poll `ble_hs_synced()` from a task, which is racy and blocks boot.

## Change

Post `ESP_BLE_CONN_EVENT_STARTED` at the end of `esp_ble_conn_on_sync()` in
`src/esp_nimble.c`, once the address is resolved and advertising/scanning have
begun. This lets applications react to host-sync purely event-driven, matching
how `CONNECTED` / `DISCONNECTED` / `DEVICE_NAME_CHANGED` are already consumed.

The bluedroid path should post the same event for parity; happy to extend this
PR if maintainers prefer.

## Testing

Built for ESP32-S3 (NimBLE, peripheral role, ESP-IDF v6.0.1); the event now
fires once on host sync and application handlers registered on
`BLE_CONN_MGR_EVENTS` receive it.

Fixes #751