### PR TITLE
feat(ble_conn_mgr): add esp_ble_conn_whitelist_sync_bonds() [draft, #752]

### DIFF
--- a/components/bluetooth/ble_conn_mgr/include/esp_ble_conn_mgr.h
+++ b/components/bluetooth/ble_conn_mgr/include/esp_ble_conn_mgr.h
@@ -1041,9 +1041,9 @@ esp_err_t esp_ble_conn_adv_params_set(const esp_ble_conn_adv_params_t *params);
  * as the controller whitelist (ble_gap_wl_set), so advertising/scanning with
  * filter_policy = ESP_BLE_CONN_SCAN_FILT_USE_WL only admits bonded peers.
  *
- * Call after a bond is added or removed. NOTE: peers that reconnect with a
- * resolvable private address (RPA) also need controller address resolution and
- * a populated resolving list, which this helper does not manage yet.
+ * Call after a bond is added or removed. RPA peers are resolved via NimBLE's own
+ * resolving list, which it maintains from bonds when CONFIG_BT_NIMBLE_HS_PVCY is
+ * enabled, so this helper manages only the plain whitelist.
  *
  * @return
  *  - ESP_OK on success

--- a/components/bluetooth/ble_conn_mgr/include/esp_ble_conn_mgr.h
+++ b/components/bluetooth/ble_conn_mgr/include/esp_ble_conn_mgr.h
@@ -1035,6 +1035,23 @@ esp_err_t esp_ble_conn_set_data_len(uint16_t conn_handle, uint16_t tx_octets, ui
 esp_err_t esp_ble_conn_adv_params_set(const esp_ble_conn_adv_params_t *params);
 
 /**
+ * @brief   Rebuild the controller whitelist from the bonded peers in the store.
+ *
+ * Reads the identity addresses of all currently bonded peers and installs them
+ * as the controller whitelist (ble_gap_wl_set), so advertising/scanning with
+ * filter_policy = ESP_BLE_CONN_SCAN_FILT_USE_WL only admits bonded peers.
+ *
+ * Call after a bond is added or removed. NOTE: peers that reconnect with a
+ * resolvable private address (RPA) also need controller address resolution and
+ * a populated resolving list, which this helper does not manage yet.
+ *
+ * @return
+ *  - ESP_OK on success
+ *  - ESP_FAIL if reading bonds or setting the whitelist fails
+ */
+esp_err_t esp_ble_conn_whitelist_sync_bonds(void);
+
+/**
  * @brief   Set local GAP device name.
  *
  *          This function updates NimBLE GAP Device Name and the internal local name.

--- a/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
+++ b/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
@@ -4088,6 +4088,28 @@ esp_err_t esp_ble_conn_periodic_adv_data_set(const uint8_t *data, uint16_t len)
 #endif
 }
 
+esp_err_t esp_ble_conn_whitelist_sync_bonds(void)
+{
+    ble_addr_t peer_addrs[CONFIG_BT_NIMBLE_MAX_BONDS];
+    int num_peers = 0;
+
+    int rc = ble_store_util_bonded_peers(peer_addrs, &num_peers,
+                                         sizeof(peer_addrs) / sizeof(peer_addrs[0]));
+    if (rc != 0) {
+        ESP_LOGE(TAG, "Failed to read bonded peers; rc=%d", rc);
+        return ESP_FAIL;
+    }
+
+    rc = ble_gap_wl_set(peer_addrs, (uint8_t)num_peers);
+    if (rc != 0) {
+        ESP_LOGE(TAG, "ble_gap_wl_set failed; rc=%d", rc);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Whitelist synced from %d bonded peer(s)", num_peers);
+    return ESP_OK;
+}
+
 esp_err_t esp_ble_conn_adv_start(void)
 {
 #if defined(CONFIG_BLE_CONN_MGR_ROLE_PERIPHERAL) || defined(CONFIG_BLE_CONN_MGR_ROLE_BOTH)


### PR DESCRIPTION
Draft prototype for #752 (Layer A). Opening as a draft to give a concrete artifact to react to — happy to reshape per maintainer preference before it's review-ready.

## What this adds

A single small helper, `esp_ble_conn_whitelist_sync_bonds()`, that rebuilds the controller whitelist from the currently bonded peers:

```c
ble_store_util_bonded_peers(peer_addrs, &num_peers, ...);
ble_gap_wl_set(peer_addrs, num_peers);
```

Apps doing bonded-only advertising/scanning (`filter_policy = USE_WL`) can then call this once after a bond changes instead of iterating `BLE_STORE_OBJ_TYPE_PEER_SEC` and calling `ble_gap_wl_set` themselves.

## Deliberately left out (open questions from #752)

- **Automatic invocation** (on bond add/remove and on host sync, behind a Kconfig) vs. this explicit helper — #752 question 2. This PR implements only the explicit helper.
- **Bluedroid parity.** NimBLE path only for now.

## Status

Untested prototype — I don't have the esp-iot-solution build set up locally, so this is for API/shape discussion rather than merge as-is. Signed off under DCO.
