### PR TITLE
feat(bootloader_support_plus): add ESP32-P4 and ESP32-S31 support

### DIFF
--- a/components/bootloader_support_plus/CHANGELOG.md
+++ b/components/bootloader_support_plus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## v0.5.0 - 2026-07-24
+
+### Improve:
+
+- Add ESP32-P4 support.
+- Add ESP32-S31 support (preview target, requires ESP-IDF with ESP32-S31 enabled).
+
 ## v0.4.1 - 2026-06-10
 
 ### Fix:

--- a/components/bootloader_support_plus/CMakeLists.txt
+++ b/components/bootloader_support_plus/CMakeLists.txt
@@ -3,7 +3,7 @@ set(srcs "src/bootloader_custom_image_format.c"
          "src/bootloader_custom_utility.c"
          )
 
-set(requires "bootloader" "bootloader_support" "spi_flash")
+set(requires "bootloader" "bootloader_support" "spi_flash" "efuse")
 
 # Since IDF v6.0 the watchdog HAL has graduated into its own component
 # (esp_hal_wdt). In earlier IDF versions hal/wdt_hal.h is provided by the

--- a/components/bootloader_support_plus/README.md
+++ b/components/bootloader_support_plus/README.md
@@ -7,16 +7,20 @@
 ## Overview
 The `bootloader support plus` is an enhanced bootloader based on [custom_bootloader](https://github.com/espressif/esp-idf/tree/master/examples/custom_bootloader) . The firmware update function is supported in the bootloader stage by decompressing the compressed firmware. In this solution, you can directly use the original OTA APIs (such as [esp_ota](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/ota.html#api-reference)、[esp_https_ota](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/esp_https_ota.html#api-reference)). The following table shows the Espressif SoCs that are compatible with `bootloader support plus` and their corresponding ESP-IDF versions.
 
-| Chip     | ESP-IDF Release/v5.0                                         | ESP-IDF Release/v5.1                                  | ESP-IDF Release/v5.4+                 | ESP-IDF Release/v5.5+                 |
-| -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |------------------------------ |------------------------------ |
-| ESP32 | Supported | Supported | Supported | Supported |
-| ESP32-S3 | N/A | Supported | Supported | Supported |
-| ESP32-C2 | Supported | Supported | Supported | Supported |
-| ESP32-C3 | Supported | Supported | Supported | Supported |
-| ESP32-C5 | N/A | N/A | Supported | Supported |
-| ESP32-C6 | N/A | Supported | Supported | Supported |
-| ESP32-H2 | N/A | Supported | Supported | Supported |
-| ESP32-C61 | N/A | N/A  | N/A | Supported |
+| Chip     | ESP-IDF Release/v5.0                                         | ESP-IDF Release/v5.1                                  | ESP-IDF Release/v5.4+                 | ESP-IDF Release/v5.5+                 | ESP-IDF Release/v6.0+                 |
+| -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |------------------------------ |------------------------------ |------------------------------ |
+| ESP32 | Supported | Supported | Supported | Supported | Supported |
+| ESP32-S3 | N/A | Supported | Supported | Supported | Supported |
+| ESP32-C2 | Supported | Supported | Supported | Supported | Supported |
+| ESP32-C3 | Supported | Supported | Supported | Supported | Supported |
+| ESP32-C5 | N/A | N/A | Supported | Supported | Supported |
+| ESP32-C6 | N/A | Supported | Supported | Supported | Supported |
+| ESP32-H2 | N/A | Supported | Supported | Supported | Supported |
+| ESP32-C61 | N/A | N/A  | N/A | Supported | Supported |
+| ESP32-P4 | N/A | N/A | N/A | N/A | Supported |
+| ESP32-S31 | N/A | N/A | N/A | N/A | Supported (preview)[^1] |
+
+[^1]: ESP32-S31 is a preview target that is not yet part of a stable ESP-IDF release; it must be enabled with `idf.py --preview set-target esp32s31` on a recent ESP-IDF master checkout.
 
 ## Compression ratio
 

--- a/components/bootloader_support_plus/README_CN.md
+++ b/components/bootloader_support_plus/README_CN.md
@@ -7,16 +7,20 @@
 ## 概述
 bootloader support plus 是乐鑫基于 [ESP-IDF](https://github.com/espressif/esp-idf) 的 [custom_bootloader](https://github.com/espressif/esp-idf/tree/master/examples/custom_bootloader)  推出的增强版 bootloader，支持在 bootloader 阶段对`压缩`的固件进行 `解压缩`，来升级原有固件。在该方案中，您可以直接使用 ESP-IDF 中原生的 OTA 接口（比如 [esp_ota](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/ota.html#api-reference)、[esp_https_ota](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/esp_https_ota.html#api-reference)）。下表总结了适配 `bootloader support plus` 的乐鑫芯片以及其对应的 ESP-IDF 版本：
 
-| Chip     | ESP-IDF Release/v5.0                                         | ESP-IDF Release/v5.1                                  | ESP-IDF Release/v5.4+                 | ESP-IDF Release/v5.5+                 |
-| -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |------------------------------ |----------------------------- |
-| ESP32 | Supported | Supported | Supported | Supported |
-| ESP32-S3 | N/A | Supported | Supported | Supported |
-| ESP32-C2 | Supported | Supported | Supported | Supported |
-| ESP32-C3 | Supported | Supported | Supported | Supported |
-| ESP32-C5 | N/A | N/A | Supported | Supported |
-| ESP32-C6 | N/A | Supported | Supported | Supported |
-| ESP32-H2 | N/A | Supported | Supported | Supported |
-| ESP32-C61 | N/A | N/A  | N/A | Supported |
+| Chip     | ESP-IDF Release/v5.0                                         | ESP-IDF Release/v5.1                                  | ESP-IDF Release/v5.4+                 | ESP-IDF Release/v5.5+                 | ESP-IDF Release/v6.0+                 |
+| -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |------------------------------ |----------------------------- |----------------------------- |
+| ESP32 | Supported | Supported | Supported | Supported | Supported |
+| ESP32-S3 | N/A | Supported | Supported | Supported | Supported |
+| ESP32-C2 | Supported | Supported | Supported | Supported | Supported |
+| ESP32-C3 | Supported | Supported | Supported | Supported | Supported |
+| ESP32-C5 | N/A | N/A | Supported | Supported | Supported |
+| ESP32-C6 | N/A | Supported | Supported | Supported | Supported |
+| ESP32-H2 | N/A | Supported | Supported | Supported | Supported |
+| ESP32-C61 | N/A | N/A  | N/A | Supported | Supported |
+| ESP32-P4 | N/A | N/A | N/A | N/A | Supported |
+| ESP32-S31 | N/A | N/A | N/A | N/A | Supported (预览版)[^1] |
+
+[^1]: ESP32-S31 目前是预览（preview）目标芯片，尚未包含在正式发布的 ESP-IDF 版本中；需要在较新的 ESP-IDF master 分支上使用 `idf.py --preview set-target esp32s31` 启用。
 
 ## 压缩率
 

--- a/components/bootloader_support_plus/idf_component.yml
+++ b/components/bootloader_support_plus/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.4.1"
+version: "0.5.0"
 targets:
   - esp32c2
   - esp32c3
@@ -8,6 +8,8 @@ targets:
   - esp32
   - esp32s3
   - esp32h2
+  - esp32p4
+  - esp32s31
 description: Provide extra bootloader support, now support upgrading the firmware by decompressing the OTA firmware in the bootloader stage.
 url: https://github.com/espressif/esp-iot-solution/tree/master/components/bootloader_support_plus
 issues: https://github.com/espressif/esp-iot-solution/issues

--- a/components/bootloader_support_plus/ld/esp32p4/linker.lf
+++ b/components/bootloader_support_plus/ld/esp32p4/linker.lf
@@ -1,0 +1,11 @@
+SECTIONS
+{
+  .xz :
+  {
+    . = ALIGN(4);
+    *libbootloader_support_plus.a:(.literal .text .literal.* .text.*)
+    *libespressif__bootloader_support_plus.a:(.literal .text .literal.* .text.*)
+    *libespressif__xz.a:(.literal .text .literal.* .text.*)
+    *libxz.a:(.literal .text .literal.* .text.*)
+  } > iram_loader_seg
+}

--- a/components/bootloader_support_plus/ld/esp32s31/linker.lf
+++ b/components/bootloader_support_plus/ld/esp32s31/linker.lf
@@ -1,0 +1,11 @@
+SECTIONS
+{
+  .xz :
+  {
+    . = ALIGN(4);
+    *libbootloader_support_plus.a:(.literal .text .literal.* .text.*)
+    *libespressif__bootloader_support_plus.a:(.literal .text .literal.* .text.*)
+    *libespressif__xz.a:(.literal .text .literal.* .text.*)
+    *libxz.a:(.literal .text .literal.* .text.*)
+  } > iram_loader_seg
+}

--- a/components/bootloader_support_plus/src/bootloader_custom_utility.c
+++ b/components/bootloader_support_plus/src/bootloader_custom_utility.c
@@ -8,7 +8,7 @@
 
 #include "esp_log.h"
 
-#include "esp_flash_encrypt.h"
+#include "esp_efuse.h"
 
 #include "bootloader_common.h"
 
@@ -111,7 +111,7 @@ esp_err_t bootloader_custom_utility_updata_ota_data(const bootloader_state_t *bs
         otadata[next_otadata].ota_seq = (boot_index + 1) % ota_app_count + i * ota_app_count;
         otadata[next_otadata].ota_state = set_new_state_otadata();
         otadata[next_otadata].crc = bootloader_common_ota_select_crc(&otadata[next_otadata]);
-        bool write_encrypted = esp_flash_encryption_enabled();
+        bool write_encrypted = esp_efuse_is_flash_encryption_enabled();
         ESP_LOGD(TAG, "next_otadata is %d and i=%" PRIu32 " and rewrite seq is %" PRIu32 "", next_otadata, i, otadata[next_otadata].ota_seq);
         return write_otadata(&otadata[next_otadata], bs->ota_info.offset + FLASH_SECTOR_SIZE * next_otadata, write_encrypted);
     } else {
@@ -120,7 +120,7 @@ esp_err_t bootloader_custom_utility_updata_ota_data(const bootloader_state_t *bs
         otadata[next_otadata].ota_seq = boot_index + 1;
         otadata[next_otadata].ota_state = set_new_state_otadata();
         otadata[next_otadata].crc = bootloader_common_ota_select_crc(&otadata[next_otadata]);
-        bool write_encrypted = esp_flash_encryption_enabled();
+        bool write_encrypted = esp_efuse_is_flash_encryption_enabled();
         ESP_LOGD(TAG, "next_otadata is %d and rewrite seq is %" PRIu32 "", next_otadata, otadata[next_otadata].ota_seq);
         return write_otadata(&otadata[next_otadata], bs->ota_info.offset + FLASH_SECTOR_SIZE * next_otadata, write_encrypted);
     }

--- a/components/bootloader_support_plus/src/bootloader_storage_flash.c
+++ b/components/bootloader_support_plus/src/bootloader_storage_flash.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 #include "esp_log.h"
-#include "esp_flash_encrypt.h"
+#include "esp_efuse.h"
 #include "esp_idf_version.h"
 #include "bootloader_flash_priv.h"
 #include "bootloader_storage_flash.h"
@@ -124,7 +124,7 @@ int bootloader_storage_flash_input(void *buf, int size)
     static uint32_t write_count = 0;
 
     if (custom_ota_config->dst_offset + size < custom_ota_config->dst_size) {
-        if (esp_flash_encryption_enabled()) {
+        if (esp_efuse_is_flash_encryption_enabled()) {
             encryption = true;
         }
         if (bootloader_storage_flash_write(custom_ota_config->dst_addr + custom_ota_config->dst_offset, buf, size, encryption) != ESP_OK) {
@@ -166,7 +166,7 @@ int bootloader_storage_flash_input(void *buf, int size)
     if (custom_ota_config->dst_offset + size < custom_ota_config->dst_size) {
         uint32_t dst_addr = custom_ota_config->dst_addr + custom_ota_config->dst_offset;
         ESP_LOGD(TAG, "write buffer %x to %x, len %d", buf, dst_addr, size);
-        if (esp_flash_encryption_enabled()) {
+        if (esp_efuse_is_flash_encryption_enabled()) {
             encryption = true;
         }
         bootloader_flash_write(custom_ota_config->dst_addr + custom_ota_config->dst_offset, buf, size, encryption);

--- a/examples/ota/simple_ota_example/bootloader_components/main/CMakeLists.txt
+++ b/examples/ota/simple_ota_example/bootloader_components/main/CMakeLists.txt
@@ -2,8 +2,15 @@ idf_component_register(SRCS "bootloader_start.c"
                     REQUIRES bootloader bootloader_support)
 
 idf_build_get_property(target IDF_TARGET)
-# Use the linker script files from the actual bootloader
-set(scripts "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.ld"
-            "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.rom.ld")
-
-target_linker_script(${COMPONENT_LIB} INTERFACE "${scripts}")
+# Use the linker script files from the actual bootloader.
+# Since IDF v6.0 the bootloader subproject's own top-level CMakeLists.txt
+# already applies bootloader.memory.ld.in/bootloader.sections.ld.in to the
+# "main" component target unconditionally (regardless of this override), so
+# re-adding them here would register the same ldgen preprocess target twice
+# and fail the build. Only pre-6.0 IDF requires this override to supply the
+# (then single, non-templated) bootloader.ld/bootloader.rom.ld explicitly.
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "6.0")
+    set(scripts "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.ld"
+                "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.rom.ld")
+    target_linker_script(${COMPONENT_LIB} INTERFACE "${scripts}")
+endif()

--- a/examples/ota/simple_ota_example/bootloader_components/main/bootloader_start.c
+++ b/examples/ota/simple_ota_example/bootloader_components/main/bootloader_start.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <sys/reent.h>
 #include "esp_log.h"
 
 #include "bootloader_init.h"
@@ -67,8 +68,10 @@ static int select_partition_number(bootloader_state_t *bs)
     return bootloader_utility_get_selected_boot_partition(bs);
 }
 
+#if CONFIG_LIBC_NEWLIB
 // Return global reent struct if any newlib functions are linked to bootloader
 struct _reent *__getreent(void)
 {
     return _GLOBAL_REENT;
 }
+#endif


### PR DESCRIPTION
## Description

Adds ESP32-P4 and ESP32-S31 to `bootloader_support_plus` by placing the `.xz` decompressor code directly in the bootloader's `iram_loader_seg`, the same approach already used for ESP32/ESP32-S3 (as opposed to the separate carved-out `iram_loader1_seg` region needed by the smaller-SRAM RISC-V chips such as C2/C3/C5/C61/H2/C6).

While verifying the change, I also found and fixed two pre-existing IDF v6.0+ compatibility bugs in `examples/ota/simple_ota_example`'s custom bootloader override. Both affect every target under IDF 6.0+, not just P4/S31, and were blocking the example from building at all on IDF 6.0+:

- `bootloader_components/main/CMakeLists.txt` referenced the pre-6.0 `bootloader.ld`/`bootloader.rom.ld` filenames. IDF 6.0 split these into `bootloader.memory.ld.in`/`bootloader.sections.ld.in` templates, which the bootloader subproject's own top-level `CMakeLists.txt` now applies to the `main` component automatically (override or not). Re-adding them in the override registered the same ldgen preprocess target twice and broke the build with a CMake `add_custom_target` name collision.
- `bootloader_components/main/bootloader_start.c` was missing `#include <sys/reent.h>` and the `#if CONFIG_LIBC_NEWLIB` guard around `__getreent()` that upstream IDF's reference `custom_bootloader/bootloader_override` example has, causing an undeclared-identifier build error.

Also bumped the component version to 0.5.0, updated `CHANGELOG.md`, and extended the compatibility table in `README.md`/`README_CN.md` with a new "ESP-IDF Release/v6.0+" column. ESP32-S31 is flagged as preview-only since it isn't part of a stable IDF release yet.

## Testing

- **ESP32-P4**: built `examples/ota/simple_ota_example` (bootloader + app, `CONFIG_BOOTLOADER_COMPRESSED_ENABLED=y`) against ESP-IDF v6.0.2. Bootloader links cleanly with no `iram_loader_seg` overflow.
- **ESP32-S31**: this target isn't wired up in IDF v6.0.2 (not in `idf.py --list-targets`, no `components/soc/esp32s31`), so I built against an ESP-IDF master checkout (v6.2.0-dev) that has ESP32-S31 as a preview target (`idf.py --preview set-target esp32s31`). Bootloader and app both build successfully with no overflow.
- Also re-verified ESP32-C6 (already-supported target) end-to-end under IDF v6.0.2 to confirm the two `simple_ota_example` compatibility fixes don't regress previously-supported chips.
- All builds done in a scratch copy of the example (component referenced via `override_path` to the local component sources), not by modifying the tracked example in place during testing.

## Checklist

- [x] This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.