### PR TITLE
fix(ota): fix simple_ota_example build under ESP-IDF v6.0.2 / Build System v2

### DIFF
--- a/components/bootloader_support_plus/CMakeLists.txt
+++ b/components/bootloader_support_plus/CMakeLists.txt
@@ -3,7 +3,7 @@ set(srcs "src/bootloader_custom_image_format.c"
          "src/bootloader_custom_utility.c"
          )
 
-set(requires "bootloader" "bootloader_support" "spi_flash")
+set(requires "bootloader" "bootloader_support" "spi_flash" "efuse")
 
 # Since IDF v6.0 the watchdog HAL has graduated into its own component
 # (esp_hal_wdt). In earlier IDF versions hal/wdt_hal.h is provided by the

--- a/components/bootloader_support_plus/src/bootloader_custom_utility.c
+++ b/components/bootloader_support_plus/src/bootloader_custom_utility.c
@@ -8,7 +8,7 @@
 
 #include "esp_log.h"
 
-#include "esp_flash_encrypt.h"
+#include "esp_efuse.h"
 
 #include "bootloader_common.h"
 
@@ -111,7 +111,7 @@ esp_err_t bootloader_custom_utility_updata_ota_data(const bootloader_state_t *bs
         otadata[next_otadata].ota_seq = (boot_index + 1) % ota_app_count + i * ota_app_count;
         otadata[next_otadata].ota_state = set_new_state_otadata();
         otadata[next_otadata].crc = bootloader_common_ota_select_crc(&otadata[next_otadata]);
-        bool write_encrypted = esp_flash_encryption_enabled();
+        bool write_encrypted = esp_efuse_is_flash_encryption_enabled();
         ESP_LOGD(TAG, "next_otadata is %d and i=%" PRIu32 " and rewrite seq is %" PRIu32 "", next_otadata, i, otadata[next_otadata].ota_seq);
         return write_otadata(&otadata[next_otadata], bs->ota_info.offset + FLASH_SECTOR_SIZE * next_otadata, write_encrypted);
     } else {
@@ -120,7 +120,7 @@ esp_err_t bootloader_custom_utility_updata_ota_data(const bootloader_state_t *bs
         otadata[next_otadata].ota_seq = boot_index + 1;
         otadata[next_otadata].ota_state = set_new_state_otadata();
         otadata[next_otadata].crc = bootloader_common_ota_select_crc(&otadata[next_otadata]);
-        bool write_encrypted = esp_flash_encryption_enabled();
+        bool write_encrypted = esp_efuse_is_flash_encryption_enabled();
         ESP_LOGD(TAG, "next_otadata is %d and rewrite seq is %" PRIu32 "", next_otadata, otadata[next_otadata].ota_seq);
         return write_otadata(&otadata[next_otadata], bs->ota_info.offset + FLASH_SECTOR_SIZE * next_otadata, write_encrypted);
     }

--- a/components/bootloader_support_plus/src/bootloader_storage_flash.c
+++ b/components/bootloader_support_plus/src/bootloader_storage_flash.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 #include "esp_log.h"
-#include "esp_flash_encrypt.h"
+#include "esp_efuse.h"
 #include "esp_idf_version.h"
 #include "bootloader_flash_priv.h"
 #include "bootloader_storage_flash.h"
@@ -124,7 +124,7 @@ int bootloader_storage_flash_input(void *buf, int size)
     static uint32_t write_count = 0;
 
     if (custom_ota_config->dst_offset + size < custom_ota_config->dst_size) {
-        if (esp_flash_encryption_enabled()) {
+        if (esp_efuse_is_flash_encryption_enabled()) {
             encryption = true;
         }
         if (bootloader_storage_flash_write(custom_ota_config->dst_addr + custom_ota_config->dst_offset, buf, size, encryption) != ESP_OK) {
@@ -166,7 +166,7 @@ int bootloader_storage_flash_input(void *buf, int size)
     if (custom_ota_config->dst_offset + size < custom_ota_config->dst_size) {
         uint32_t dst_addr = custom_ota_config->dst_addr + custom_ota_config->dst_offset;
         ESP_LOGD(TAG, "write buffer %x to %x, len %d", buf, dst_addr, size);
-        if (esp_flash_encryption_enabled()) {
+        if (esp_efuse_is_flash_encryption_enabled()) {
             encryption = true;
         }
         bootloader_flash_write(custom_ota_config->dst_addr + custom_ota_config->dst_offset, buf, size, encryption);

--- a/examples/ota/simple_ota_example/CMakeLists.txt
+++ b/examples/ota/simple_ota_example/CMakeLists.txt
@@ -1,11 +1,15 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
+
+include($ENV{IDF_PATH}/tools/cmakev2/idf.cmake)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
 set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(simple_ota)
+project(simple_ota C CXX ASM)
+
+idf_project_default()
+
 include(gen_compressed_ota)

--- a/examples/ota/simple_ota_example/bootloader_components/main/CMakeLists.txt
+++ b/examples/ota/simple_ota_example/bootloader_components/main/CMakeLists.txt
@@ -2,8 +2,16 @@ idf_component_register(SRCS "bootloader_start.c"
                     REQUIRES bootloader bootloader_support)
 
 idf_build_get_property(target IDF_TARGET)
-# Use the linker script files from the actual bootloader
-set(scripts "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.ld"
-            "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.rom.ld")
+# Use the linker script files from the actual bootloader.
+# Since IDF v6.0 the bootloader subproject's own top-level CMakeLists.txt
+# already applies bootloader.memory.ld.in/bootloader.sections.ld.in to the
+# "main" component target unconditionally (regardless of this override), so
+# re-adding them here would register the same ldgen preprocess target twice
+# and fail the build. Only pre-6.0 IDF requires this override to supply the
+# (then single, non-templated) bootloader.ld/bootloader.rom.ld explicitly.
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "6.0")
+    set(scripts "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.ld"
+                "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.rom.ld")
+    target_linker_script(${COMPONENT_LIB} INTERFACE "${scripts}")
+endif()
 
-target_linker_script(${COMPONENT_LIB} INTERFACE "${scripts}")

--- a/examples/ota/simple_ota_example/bootloader_components/main/CMakeLists.txt
+++ b/examples/ota/simple_ota_example/bootloader_components/main/CMakeLists.txt
@@ -3,15 +3,23 @@ idf_component_register(SRCS "bootloader_start.c"
 
 idf_build_get_property(target IDF_TARGET)
 # Use the linker script files from the actual bootloader.
-# Since IDF v6.0 the bootloader subproject's own top-level CMakeLists.txt
-# already applies bootloader.memory.ld.in/bootloader.sections.ld.in to the
-# "main" component target unconditionally (regardless of this override), so
-# re-adding them here would register the same ldgen preprocess target twice
-# and fail the build. Only pre-6.0 IDF requires this override to supply the
-# (then single, non-templated) bootloader.ld/bootloader.rom.ld explicitly.
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_LESS "6.0")
+    # Pre-6.0 IDF ships a single, non-templated bootloader.ld/bootloader.rom.ld
+    # pair that the default "main" component's own CMakeLists.txt would
+    # normally attach; since this component replaces "main" entirely, supply
+    # them explicitly.
     set(scripts "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.ld"
                 "${IDF_PATH}/components/bootloader/subproject/main/ld/${target}/bootloader.rom.ld")
-    target_linker_script(${COMPONENT_LIB} INTERFACE "${scripts}")
+else()
+    # IDF >= 6.0, Build System v1: bootloader/subproject/CMakeLists.txt attaches
+    # bootloader.memory.ld.in/bootloader.sections.ld.in directly to the
+    # "__idf_main" target regardless of which component is registered as
+    # "main", so BOOTLOADER_LINKER_SCRIPT is unset here and this is a no-op.
+    # IDF >= 6.0, Build System v2: CMakeLists_v2.txt only stores the scripts in
+    # the BOOTLOADER_LINKER_SCRIPT property and expects the "main" component to
+    # apply them itself (mirroring subproject/main/CMakeLists.txt), so fetch
+    # and apply them here to cover that case.
+    idf_build_get_property(scripts BOOTLOADER_LINKER_SCRIPT)
 endif()
+target_linker_script(${COMPONENT_LIB} INTERFACE "${scripts}")
 

--- a/examples/ota/simple_ota_example/bootloader_components/main/bootloader_start.c
+++ b/examples/ota/simple_ota_example/bootloader_components/main/bootloader_start.c
@@ -67,8 +67,10 @@ static int select_partition_number(bootloader_state_t *bs)
     return bootloader_utility_get_selected_boot_partition(bs);
 }
 
+#if CONFIG_LIBC_NEWLIB
 // Return global reent struct if any newlib functions are linked to bootloader
 struct _reent *__getreent(void)
 {
     return _GLOBAL_REENT;
 }
+#endif

--- a/examples/ota/simple_ota_example/main/CMakeLists.txt
+++ b/examples/ota/simple_ota_example/main/CMakeLists.txt
@@ -2,4 +2,6 @@
 idf_build_get_property(project_dir PROJECT_DIR)
 idf_component_register(SRCS "simple_ota_example.c"
                     INCLUDE_DIRS "."
+                    PRIV_REQUIRES esp_event app_update esp_http_client esp_https_ota
+                                  protocol_examples_common mbedtls nvs_flash esp_wifi lwip
                     EMBED_TXTFILES ${project_dir}/server_certs/ca_cert.pem)

--- a/examples/ota/simple_ota_example/main/simple_ota_example.c
+++ b/examples/ota/simple_ota_example/main/simple_ota_example.c
@@ -58,6 +58,12 @@ esp_err_t _http_event_handler(esp_http_client_event_t *evt)
     case HTTP_EVENT_ON_HEADER:
         ESP_LOGD(TAG, "HTTP_EVENT_ON_HEADER, key=%s, value=%s", evt->header_key, evt->header_value);
         break;
+    case HTTP_EVENT_ON_HEADERS_COMPLETE:
+        ESP_LOGD(TAG, "HTTP_EVENT_ON_HEADERS_COMPLETE");
+        break;
+    case HTTP_EVENT_ON_STATUS_CODE:
+        ESP_LOGD(TAG, "HTTP_EVENT_ON_STATUS_CODE");
+        break;
     case HTTP_EVENT_ON_DATA:
         ESP_LOGD(TAG, "HTTP_EVENT_ON_DATA, len=%d", evt->data_len);
         break;

--- a/tools/cmake_utilities/CHANGELOG.md
+++ b/tools/cmake_utilities/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.1.2 - 2026-08-03
+
+### Bugfix:
+
+* gen_compressed_ota: fix `CMake Error: The dependency target "gen_project_binary" ... does not exist` under ESP-IDF Build System v2 by depending on the version-agnostic `app` target instead of the Build System v1-only `gen_project_binary` target
+* gen_single_bin: same `gen_project_binary` -> `app` fix as above
+
 ## v1.1.1 - 2025-02-25
 
 * relinker: some typo

--- a/tools/cmake_utilities/gen_compressed_ota.cmake
+++ b/tools/cmake_utilities/gen_compressed_ota.cmake
@@ -14,5 +14,8 @@ if (NOT TARGET gen_compressed_ota)
     COMMAND ${PYTHON} ${GEN_COMPRESSED_BIN_CMD}
     COMMENT "The gen compressed bin cmd is: ${GEN_COMPRESSED_BIN_CMD}"
     )
-    add_dependencies(gen_compressed_ota gen_project_binary)
+    # "app" is the build-system-version-agnostic alias for the final app
+    # binary target: Build System v1 additionally exposes the legacy
+    # "gen_project_binary" name, but Build System v2 only creates "app".
+    add_dependencies(gen_compressed_ota app)
 endif()

--- a/tools/cmake_utilities/gen_single_bin.cmake
+++ b/tools/cmake_utilities/gen_single_bin.cmake
@@ -8,7 +8,7 @@ if (NOT TARGET gen_single_bin)
         COMMAND ${ESPTOOLPY} --chip ${IDF_TARGET} merge_bin -o ${CMAKE_PROJECT_NAME}_merged.bin @flash_args
         COMMAND ${CMAKE_COMMAND} -E echo "Merge bin done"
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        DEPENDS gen_project_binary bootloader
+        DEPENDS app bootloader
         VERBATIM USES_TERMINAL
     )
 endif()

--- a/tools/cmake_utilities/idf_component.yml
+++ b/tools/cmake_utilities/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1"
+version: "1.1.2"
 description: A collection of useful cmake utilities
 url: https://github.com/espressif/esp-iot-solution/tree/master/tools/cmake_utilities
 documentation: https://docs.espressif.com/projects/esp-iot-solution/zh_CN/latest/basic/cmake_utilities.html


### PR DESCRIPTION
## Description

Fixes `examples/ota/simple_ota_example` so it builds again against a current ESP-IDF (v6.0.2), and additionally makes it (and the `cmake_utilities` tool it uses) compatible with the new ESP-IDF **Build System v2** technical preview.

Three changes, in order:

1. **`fix(ota): fix simple_ota_example build with ESP-IDF v6.0.2`**
   - The custom bootloader `main` override duplicated the bootloader's linker-script registration, which IDF v6.0 now attaches automatically; fixed to only supply the (now templated) scripts where actually needed.
   - The same override unconditionally defined `__getreent()`, which only exists under newlib. IDF v6.0 defaults to picolibc, so guard it with `#if CONFIG_LIBC_NEWLIB` (matching upstream's own bootloader `main.c`).
   - Handle two new `esp_http_client` event IDs added in this IDF version so the `switch` doesn't fail under `-Werror=switch`.

2. **`fix(cmake_utilities): make gen_compressed_ota/gen_single_bin compatible with Build System v2`**
   - Both cmake modules depended on the `gen_project_binary` target, which only exists under Build System v1. Switched to `app`, the version-agnostic alias for the final app binary target that both v1 and v2 create.
   - Bumped `cmake_utilities` to v1.1.2 with a CHANGELOG entry.

3. **`refactor(ota): migrate simple_ota_example to ESP-IDF Build System v2`**
   - Switched the project's top-level `CMakeLists.txt` to the `cmakev2` boilerplate (`tools/cmakev2/idf.cmake` + `idf_project_default()`).
   - Build System v2 no longer implicitly makes every component visible to `main`; added the `PRIV_REQUIRES` actually used by `simple_ota_example.c`.
   - The bootloader subproject's v2 CMakeLists only exposes its linker scripts via the `BOOTLOADER_LINKER_SCRIPT` build property instead of attaching them directly, so the custom `bootloader_components/main` override now fetches and applies that property itself under IDF >= 6.0 (a no-op under v1, which still attaches the scripts directly regardless of this override).

## Related

None.

## Testing

Built `examples/ota/simple_ota_example` for `esp32` locally against ESP-IDF v6.0.2, from a clean `build/` directory each time:

- Build System v1 (default): full clean build succeeds, `bootloader.bin` and `simple_ota.bin` generated correctly.
- Build System v2 (`idf_project_default()`, technical preview): full clean build succeeds; verified the bootloader's linker scripts are attached correctly (no missing memory-region warnings) and that `gen_compressed_ota`/`gen_single_bin` resolve their `app` dependency without the prior `gen_project_binary`-not-found CMake error.

Not flashed to real hardware.

---

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed. *(CHANGELOG.md for cmake_utilities; no other docs affected)*
- [ ] Tests are updated or added as necessary. *(no automated tests exist for this example)*
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
