### PR TITLE
fix(ble_conn_mgr): stop the advertising restart failing on its own two paths

### DIFF
--- a/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
+++ b/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
@@ -1953,7 +1953,13 @@ static esp_err_t esp_ble_conn_ext_advertise(esp_ble_conn_session_t *conn_session
            refuses to reprogram. Stop it and take one more run: returning here
            leaves the instance advertising with the previous parameters, which
            is harder to notice than a failure to advertise at all. */
-        ble_gap_ext_adv_stop(conn_session->ext_adv_handle);
+        int stop_rc = ble_gap_ext_adv_stop(conn_session->ext_adv_handle);
+        /* EALREADY means the set ended between the two calls (a connection, or
+           duration expiry). The disable was still sent, so the retry is valid. */
+        if (stop_rc != 0 && stop_rc != BLE_HS_EALREADY) {
+            ESP_LOGE(TAG, "Stop extended advertising instance for reconfigure error; rc=%d", stop_rc);
+            return ESP_FAIL;
+        }
         rc = ble_gap_ext_adv_configure(conn_session->ext_adv_handle, &adv_params, NULL,
                                        esp_ble_conn_gap_event, conn_session);
     }

--- a/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
+++ b/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
@@ -1948,6 +1948,15 @@ static esp_err_t esp_ble_conn_ext_advertise(esp_ble_conn_session_t *conn_session
     /* configure instance */
     rc = ble_gap_ext_adv_configure(conn_session->ext_adv_handle, &adv_params, NULL,
                                    esp_ble_conn_gap_event, conn_session);
+    if (rc == BLE_HS_EBUSY) {
+        /* The instance is still enabled, which ble_gap_ext_adv_configure()
+           refuses to reprogram. Stop it and take one more run: returning here
+           leaves the instance advertising with the previous parameters, which
+           is harder to notice than a failure to advertise at all. */
+        ble_gap_ext_adv_stop(conn_session->ext_adv_handle);
+        rc = ble_gap_ext_adv_configure(conn_session->ext_adv_handle, &adv_params, NULL,
+                                       esp_ble_conn_gap_event, conn_session);
+    }
     if (rc) {
         ESP_LOGE(TAG, "Configure extended advertising instance error; rc=%d", rc);
         return ESP_FAIL;
@@ -2504,6 +2513,14 @@ static int esp_ble_conn_gap_event(struct ble_gap_event *event, void *arg)
         case BLE_GAP_EVENT_ADV_COMPLETE:
 #if BLE_CONN_MGR_NIMBLE_USE_EXT_GAP
             if (event->adv_complete.instance != conn_session->ext_adv_handle) {
+                break;
+            }
+            /* reason 0 means the advertising set terminated because a connection
+               was established. Restarting connectable advertising with the slot
+               taken fails with BLE_HS_ENOMEM and leaves the previously
+               configured parameters in force; BLE_GAP_EVENT_DISCONNECT is what
+               resumes advertising. */
+            if (event->adv_complete.reason == 0) {
                 break;
             }
 #endif


### PR DESCRIPTION
Fixes #769.

Two independent failures on the advertising restart path, both no-API-change.

## 1. Do not restart on ADV_COMPLETE when a connection ended the set

`reason == 0` means the advertising set terminated because a connection was
established, so the restart runs with the slot occupied and
`ble_gap_ext_adv_start()` returns `BLE_HS_ENOMEM` (`rc=6`). The attempt is not
free: `ble_gap_ext_adv_configure()` and `ble_gap_ext_adv_set_data()` have
already run, so the instance is left carrying a parameter set that was never
enabled. `BLE_GAP_EVENT_DISCONNECT` is what resumes advertising.

The check sits **inside** the extended-GAP block deliberately — on the legacy
path `ble_gap_adv_finished(0, 0, 0, 0)` also reports reason 0 for a
directed-advertising timeout, where restarting is correct.

## 2. Treat EBUSY from configure as stop-and-retry

`ble_gap_ext_adv_configure()` returns `BLE_HS_EBUSY` for an instance that is
still enabled. Returning `ESP_FAIL` there leaves the instance advertising with
the *previous* parameters, so a filter policy or interval change silently does
not apply and the only symptom is `rc=15`. Stopping the instance and
configuring once more fails loudly instead of succeeding wrongly.

## Testing

Compiled against ESP-IDF v6.0.2 for ESP32-S3 with the project's own flags
(`-std=gnu23`, NimBLE, peripheral role, `CONFIG_BLE_CONN_MGR_EXTENDED_ADV=y`,
`CONFIG_BT_NIMBLE_MAX_CONNECTIONS=1`), clean.

The `rc=6` line disappears from connection establishment; the `rc=15` path is
the one #769 describes and is not reachable on demand without racing the host
task, so that half is reasoned rather than reproduced on the bench.

I left the version bump and CHANGELOG entry out — happy to add them here if you
would rather they travelled with the change.
