### PR TITLE
feat(ble_conn_mgr): let an application read back its advertising state

### DIFF
--- a/components/bluetooth/ble_conn_mgr/include/esp_ble_conn_mgr.h
+++ b/components/bluetooth/ble_conn_mgr/include/esp_ble_conn_mgr.h
@@ -1026,6 +1026,11 @@ esp_err_t esp_ble_conn_set_data_len(uint16_t conn_handle, uint16_t tx_octets, ui
 /**
  * @brief   Configure advertising parameters.
  *
+ * @note    The parameters are stored and take effect the next time advertising
+ *          starts. Unlike @c esp_ble_conn_adv_data_set(), this does not reapply
+ *          them to an advertising instance that is already active; stop and
+ *          start advertising to change the parameters of a live instance.
+ *
  * @param[in] params  Advertising parameters (NULL to use defaults)
  *
  * @return
@@ -1033,6 +1038,23 @@ esp_err_t esp_ble_conn_set_data_len(uint16_t conn_handle, uint16_t tx_octets, ui
  *  - ESP_ERR_INVALID_STATE if BLE connection manager is not initialized
  */
 esp_err_t esp_ble_conn_adv_params_set(const esp_ble_conn_adv_params_t *params);
+
+/**
+ * @brief   Read back the configured advertising parameters.
+ *
+ * @note    This reports intent, not what is on air: the block returned is the
+ *          one that is or would be programmed at the next advertising start.
+ *          Use @c esp_ble_conn_adv_is_active() to find out whether the
+ *          controller is advertising with it.
+ *
+ * @param[out] out_params  Receives the currently configured parameters.
+ *
+ * @return
+ *  - ESP_OK on success
+ *  - ESP_ERR_INVALID_STATE if BLE connection manager is not initialized
+ *  - ESP_ERR_INVALID_ARG if out_params is NULL
+ */
+esp_err_t esp_ble_conn_adv_params_get(esp_ble_conn_adv_params_t *out_params);
 
 /**
  * @brief   Rebuild the controller whitelist from the bonded peers in the store.
@@ -1136,6 +1158,22 @@ esp_err_t esp_ble_conn_adv_start(void);
  *  - ESP_FAIL on other error
  */
 esp_err_t esp_ble_conn_adv_stop(void);
+
+/**
+ * @brief   Whether the advertising instance is currently on air (peripheral role).
+ *
+ * @note    This reports what the controller is doing, which is not always what
+ *          was asked for: advertising also stops on its own when a connection
+ *          is established, and a start can fail.
+ *
+ * @param[out] out_active  Receives true while advertising.
+ *
+ * @return
+ *  - ESP_OK on success
+ *  - ESP_ERR_INVALID_STATE if not initialized or not in peripheral role
+ *  - ESP_ERR_INVALID_ARG if out_active is NULL
+ */
+esp_err_t esp_ble_conn_adv_is_active(bool *out_active);
 
 /**
  * @brief   Configure scan parameters.

--- a/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
+++ b/components/bluetooth/ble_conn_mgr/src/esp_nimble.c
@@ -3736,6 +3736,19 @@ esp_err_t esp_ble_conn_adv_params_set(const esp_ble_conn_adv_params_t *params)
     return ESP_OK;
 }
 
+esp_err_t esp_ble_conn_adv_params_get(esp_ble_conn_adv_params_t *out_params)
+{
+    if (!s_conn_session) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!out_params) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *out_params = s_conn_session->adv_params_cfg;
+    return ESP_OK;
+}
+
 static uint16_t esp_ble_conn_adv_data_max_len(void)
 {
 #if defined(CONFIG_BLE_CONN_MGR_EXTENDED_ADV) && defined(CONFIG_BT_NIMBLE_EXT_ADV_MAX_SIZE)
@@ -4144,6 +4157,28 @@ esp_err_t esp_ble_conn_adv_stop(void)
     ESP_LOGW(TAG, "Failed to stop advertising; rc=%d", rc);
     return ESP_FAIL;
 #else
+    return ESP_ERR_INVALID_STATE;
+#endif
+}
+
+esp_err_t esp_ble_conn_adv_is_active(bool *out_active)
+{
+#if defined(CONFIG_BLE_CONN_MGR_ROLE_PERIPHERAL) || defined(CONFIG_BLE_CONN_MGR_ROLE_BOTH)
+    if (!s_conn_session) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!out_active) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+#if BLE_CONN_MGR_NIMBLE_USE_EXT_GAP
+    *out_active = ble_gap_ext_adv_active(s_conn_session->ext_adv_handle) != 0;
+#else
+    *out_active = ble_gap_adv_active() != 0;
+#endif
+    return ESP_OK;
+#else
+    (void)out_active;
     return ESP_ERR_INVALID_STATE;
 #endif
 }


### PR DESCRIPTION
Fixes #770.

Adds the two getters the component is missing, both additive.

```c
/* Intent: the block that is, or would be, programmed at the next start. */
esp_err_t esp_ble_conn_adv_params_get(esp_ble_conn_adv_params_t *out_params);

/* Reality: whether the controller is advertising right now. */
esp_err_t esp_ble_conn_adv_is_active(bool *out_active);
```

They are kept separate because they answer different questions. An application
that conflates them — by caching what it last set — reports "advertising" for
the whole duration of every connection, which is when the question actually
gets asked. `adv_is_active` wraps `ble_gap_ext_adv_active()` /
`ble_gap_adv_active()` so a caller does not need to know which one its build
resolves to.

Also documents the existing asymmetry between `esp_ble_conn_adv_params_set()`
(stores for the next start) and `esp_ble_conn_adv_data_set()` (reapplies to a
live instance). No behaviour change — the note just makes the natural wrong
assumption harder to make.

NimBLE path only, matching how the rest of the advertising API is implemented.

## Testing

Compiled against ESP-IDF v6.0.2 for ESP32-S3 with the project's own flags
(`-std=gnu23`, NimBLE, peripheral role, `CONFIG_BLE_CONN_MGR_EXTENDED_ADV=y`),
clean. The `#else` arms — legacy GAP and non-peripheral roles — are not covered
by that configuration.

Version bump and CHANGELOG entry left out; happy to add them here if you prefer
them in the same PR.
